### PR TITLE
Add parens to World Series 2016 filter to enforce word boundaries

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -252,7 +252,7 @@
 					"target" : "any",
 					"operator" : "contains",
 					"condition" : {
-						"text" : "World Series|WorldSeries|Indians|Cubs|Cubbies|Wrigley|Progressive Field|home run|homerun|double play|inning|Bartman|joe buck|caray|schwarber|salazar|rizzo|kris bryant|baez"
+						"text" : "(World Series|WorldSeries|Indians|Cubs|Cubbies|Wrigley|Progressive Field|home run|homerun|double play|inning|Bartman|joe buck|caray|schwarber|salazar|rizzo|kris bryant|baez)"
 					}
 				}
 			],


### PR DESCRIPTION
Unclear whether this filter still needs to exist at all; but is there even a way to retire one?

I'd also want to tighten up "baez" so Joan doesn't suffer, but ... eh.