### PR TITLE
Remove false match, improve action match of Sponsored filter

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -45,19 +45,13 @@
 				"target": "any",
 				"operator": "contains_selector",
 				"condition": {
-					"text": "img[src*=\"facebook.com%2Fads%2Fimage%2F\"]"
-				}
-			}, {
-				"target": "any",
-				"operator": "contains_selector",
-				"condition": {
 					"text": "span>a[href^=\"/about/ads\"]"
 				}
 			}, {
-				"target": "any",
+				"target": "action",
 				"operator": "contains",
 				"condition": {
-					"text": "Suggested Post"
+					"text": "(Sponsored|Suggested)\\s*($|Post|Game)"
 				}
 			}],
 			"actions": [{


### PR DESCRIPTION
- Remove false-matching selector "img[src*=\"facebook.com%2Fads%2Fimage%2F\"]"
- Match "action" strings against the right field and add "Suggested Game"