### PR TITLE
Make "Remove Status Background Colors" less sensitive to post structure

### DIFF
--- a/tweaks.json
+++ b/tweaks.json
@@ -24,7 +24,7 @@
 			"id" : 7,
 			"title": "Remove Status Background Colors",
 			"description": "Facebook recently introduced a feature to allow users to select a background color for their status updates. This tweak removes the background and returns the posts to normal.",
-			"css": ".userContent > *[style*=\"background-\"] {\n  background-image:none !important;\n  background-color:inherit !important;\n  position: static !important;\n}\n.userContent > *[style*=\"background-\"] span[aria-hidden] {\n  visibility:visible !important;\n  color:black!important;\n  font-size:inherit !important;\n  line-height:inherit !important;\n  font-weight:normal !important;\n  text-align:left !important;\n  padding:0px 12px !important;\n}\n.userContent > *[style*=\"background-\"] span[style*=\"padding-top\"] {\n  padding-top:0 !important;\n}\n.userContent > *[style*=\"background-\"] > span~span {\n  display:none !important;\n}"
+			"css": "[sfx_post] [data-ft] > *[style*=\"background-\"] {\n  background-image:none !important;\n  background-color:inherit !important;\n}\n[sfx_post] [data-ft] > *[style*=\"background-\"] span[style*=\"color\"][role=\"presentation\"] {\n  visibility:visible !important;\n  color:inherit !important;\n  font-size:inherit !important;\n  line-height:inherit !important;\n  font-weight:inherit !important;\n  text-align:left !important;\n  padding:0px 12px !important;\n}\n[sfx_post] [data-ft] > *[style*=\"background-\"] span[style*=\"padding-top\"] {\n  padding-top:0 !important;\n}\n[sfx_post] [data-ft] > *[style*=\"background-\"] span[style*=\"color\"]:not([role=\"presentation\"]) {\n  display:none !important;\n}"
 		}
 	]
 }

--- a/tweaks.json
+++ b/tweaks.json
@@ -24,7 +24,7 @@
 			"id" : 7,
 			"title": "Remove Status Background Colors",
 			"description": "Facebook recently introduced a feature to allow users to select a background color for their status updates. This tweak removes the background and returns the posts to normal.",
-			"css": "[sfx_post] [data-ft] > *[style*=\"background-\"] {\n  background-image:none !important;\n  background-color:inherit !important;\n}\n[sfx_post] [data-ft] > *[style*=\"background-\"] span[style*=\"color\"][role=\"presentation\"] {\n  visibility:visible !important;\n  color:inherit !important;\n  font-size:inherit !important;\n  line-height:inherit !important;\n  font-weight:inherit !important;\n  text-align:left !important;\n  padding:0px 12px !important;\n}\n[sfx_post] [data-ft] > *[style*=\"background-\"] span[style*=\"padding-top\"] {\n  padding-top:0 !important;\n}\n[sfx_post] [data-ft] > *[style*=\"background-\"] span[style*=\"color\"]:not([role=\"presentation\"]) {\n  display:none !important;\n}"
+			"css": "[sfx_post] [data-ft] > div[style*=\"background-\"] {\n  background-image:none !important;\n  background-color:inherit !important;\n}\n[sfx_post] [data-ft] > div[style*=\"background-\"] span[style*=\"color\"][role=\"presentation\"] {\n  visibility:visible !important;\n  color:inherit !important;\n  font-size:inherit !important;\n  line-height:inherit !important;\n  font-weight:inherit !important;\n  text-align:left !important;\n  padding:0px 12px !important;\n}\n[sfx_post] [data-ft] > div[style*=\"background-\"] span[style*=\"padding-top\"] {\n  padding-top:0 !important;\n}\n[sfx_post] [data-ft] > div[style*=\"background-\"] span[style*=\"color\"]:not([role=\"presentation\"]) {\n  display:none !important;\n}"
 		}
 	]
 }


### PR DESCRIPTION
.userContent has gone back to .fbUserContent for me.

We don't need a specific reference to either; `[data-ft] > *[style*="background-"]` is unique.  For robustness, wrap in [sfx_post] so we only affect what we've recognized as a post.

github says in red "Can't automatically merge", yet seemed to think my local repository was identical to upstream/master when I branched off this small commit... also says "don't worry, you can still create the pull request" so I'm going ahead to see what happens...