### PR TITLE
add 'likes' to Friend Activity Stories (+ other refinements)

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -229,7 +229,7 @@
 			"target": "action",
 			"operator": "matches",
 			"condition": {
-				"text": "(.*(commented on this|was mentioned in a post|was live| likes |liked this|reacted to this|was tagged in|replied to a comment).*)"
+				"text": "(.*(commented on this|was mentioned in a post|was live| likes | liked |reacted to this|was tagged in|replied to a comment).*)"
 			}
 		}],
 		"actions": [{

--- a/filters.json
+++ b/filters.json
@@ -222,16 +222,19 @@
 		"description": "Filter the \"People You May Know\" story that appears in the News Feed occasionally."
 	}, {
 		"id": 11,
+		"updated_on": 1493344578822,
 		"match": "ALL",
 		"enabled": true,
 		"rules": [{
 			"target": "action",
-			"operator": "contains",
+			"operator": "matches",
 			"condition": {
-				"text": "(commented on this|was mentioned in a post|was live|liked this|reacted to this|was tagged in|replied to a comment)"
+				"text": "(.*(commented on this|was mentioned in a post|was live| likes |liked this|reacted to this|was tagged in|replied to a comment).*)"
 			}
 		}],
 		"actions": [{
+			"show_note": true,
+			"custom_note": "$1",
 			"action": "move-to-tab",
 			"tab": "Friend Activity"
 		}],


### PR DESCRIPTION
- change to case-sensitive matching to minimize false matches
- add ' likes ', as seen in https://facebook.com/1310697838999094
- parenthesize the whole expression with (.* .*) so that the whole 'Action' is captured
- provide "show_note: true" and "custom_note: $1" so that if the user changes action from 'move-to-tab' to 'hide', it magically displays the action field
- includes "updated_on" field (please check that this does not interact negatively with the subscription service?)
- WARNING WARNING WARNING -- I have tested this in SFx myself, but am hand-editing the JSON here and have not done end-to-end testing that it still works when injected into the subscription stream!  Please verify!