### PR TITLE
Supply a currently working 'Sponsored / Suggested' filter:

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -49,10 +49,10 @@
 				"text": "span>a[href^=\"/about/ads\"]"
 			}
 		}, {
-			"target": "action",
-			"operator": "contains",
+			"target": "any",
+			"operator": "matches",
 			"condition": {
-				"text": "(Sponsored|Suggested)\\s*($|Post|Game)"
+				"text": "^.{0,180}(Sponsored|Suggested)\\s+([A-Z][a-z]*|)\\s*\\xB7"
 			}
 		}],
 		"actions": [{


### PR DESCRIPTION
- Use the 'center-dot' endpoint to anchor the search
- 180 chars from beginning has caught every one I've seen for 2 days
- 'matches' rather than 'contains', to make it a case-sensitive search
- Should be nearly proof against false matches
- Breaks instantly if FB change that separator char; that's what the subscription model is for...

See https://facebook.com/1241563505928397 for current in-progress discussion about fixing this.  "Sponsored filter isn't working" is our #1 FAQ right now.

BTW, at least some of the CSS-based filtering is still working -- I have those elements circled by a CSS tweak and they are circled on most of the filtered posts.

I do believe something should be done to how 'Action' is scraped, so that it pulls all text before the timestamp.  But this is more immediate (no code change -> no 'store' delays).