### PR TITLE
- filters.json: currently effective selectors for Sponsored/Suggested

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -28,25 +28,13 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": ".uiStreamSponsoredLink"
+				"text": "._4dcu,._8mc"
 			}
 		}, {
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "a[href*=\"hc_ref=ADS\"]"
-			}
-		}, {
-			"target": "any",
-			"operator": "contains_selector",
-			"condition": {
-				"text": "a[href*=\"fb_source=ad\"]"
-			}
-		}, {
-			"target": "any",
-			"operator": "contains_selector",
-			"condition": {
-				"text": "span>a[href^=\"/about/ads\"]"
+				"text": ".uiStreamSponsoredLink,a[href*='hc_ref=ADS'],a[href*='fb_source=ad'],span>a[href^='/about/ads']"
 			}
 		}, {
 			"target": "any",


### PR DESCRIPTION
Unfortunately this has to resort to the ugly internal ._#$% selectors.  But it works.

I retained but coalesced the older selectors.  Note that none of them are working for *me*; but since FB pushes different junk to every user, I can't be certain.  I would support pushing a version completely lacking the ".uiStreamSponsoredLink,..." multi-selector *if* you were standing ready, hair-trigger, to put them back if users started complaining...