### PR TITLE
- filters.json: use ._5u5j to focus the primary container

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -27,13 +27,13 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "div[id^='feed_subtitle_'] a[class*='StreamPrivacy']"
+				"text": "._5u5j div[id^='feed_subtitle_'] a[class*='StreamPrivacy']"
 			}
 		}, {
 			"target": "any",
 			"operator": "not_contains_selector",
 			"condition": {
-				"text": "div[id^='feed_subtitle_'] [class*='timestamp']"
+				"text": "._5u5j div[id^='feed_subtitle_'] [class*='timestamp']"
 			}
 		}],
 		"actions": [{


### PR DESCRIPTION
This catches sponsored posts of the 'advertiser shared [advertiser's] post' form, where the inner post has a timestamp but the outer still doesn't.