### PR TITLE
New hiders for Reminder types; Donate Button importunity; 'Page: Friends and (name of page)'

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -5,7 +5,7 @@
 		,{"id":3,"name":"Right Col: Sponsored Pagelet","selector":".ego_column .adsCategoryTitleLink","parent":".pagelet"}
 		,{"id":4,"name":"Right Col: Footer","selector":"#pagelet_rhc_footer"}
 		,{"id":5,"name":"Right Col: Trending Pagelet","selector":"#pagelet_trending_tags_and_topics"}
-		,{"id":6,"name":"Right Col: Reminders","selector":"#pagelet_reminders"}
+		,{"id":6,"name":"Right Col: Reminders (RECOMMEND: HIDE INDIVIDUAL ITEMS)","selector":"#pagelet_reminders"}
 		,{"id":7,"name":"Right Col: Games Pagelet","selector":"#pagelet_games_rhc"}
 		,{"id":8,"name":"Left Col: Favorites","selector":"#pinnedNav"}
 		,{"id":9,"name":"Left Col: Pages (1)","selector":"#pagesNav"}
@@ -123,5 +123,11 @@
 		,{"id":197,"name":"Right Col: What Your Friends Are Watching","selector":"#pagelet_video_home_friends_watching_rhc"}
 		,{"id":198,"name":"Right Col: Sponsored Pagelet (3)","selector":"a[href*='/ad_campaign/'],a[href*='paid-social'],a[data-gt*='ad_account_id']","parent":".pagelet"}
 		,{"id":199,"name":"News Feed: Stories","selector":"#stories_pagelet_below_composer"}
+		,{"id":200,"name":"Right Col: Reminders: Events","selector":"#event_reminders_link,a[href*='/events/']","parent":".fbRemindersStory"}
+		,{"id":201,"name":"Right Col: Reminders: Birthdays","selector":"a[ajaxify*='/birthday/']","parent":".fbRemindersStory"}
+		,{"id":202,"name":"Right Col: Reminders: Games","selector":"form[action*='/games/']","parent":".fbRemindersStory"}
+		,{"id":203,"name":"Right Col: Reminders: Ticker Toggle","selector":".tickerToggleWrapper"}
+		,{"id":204,"name":"Post: Add a Donate Button","selector":"a[ajaxify^='/fundraiser'],a[href^='/fundraiser']","parent":"._8fo,._2z1l"}
+		,{"id":205,"name":"Page: Friends and (name of page)","selector":"a[ajaxify^='/page_likers_and_visitors_dialog/']","parent":"._4-u2"}
 	]
 }


### PR DESCRIPTION
- hideable.json: add '(RECOMMEND: HIDE INDIVIDUAL ITEMS)' to title of old 'Right Col: Reminders'
- hideable.json: add 'Right Col: Reminders: Events'
![hide-events](https://user-images.githubusercontent.com/3022180/37275222-d33ff1f0-259b-11e8-8d38-ff309bc56d9f.png)
- hideable.json: add 'Right Col: Reminders: Birthdays'
- hideable.json: add 'Right Col: Reminders: Games'
- hideable.json: add 'Right Col: Reminders: Ticker Toggle' (probably obsolete)
- hideable.json: add 'Post: Add a Donate Button'
![hide-donate](https://user-images.githubusercontent.com/3022180/37274904-0464cff4-259b-11e8-9029-8b5eaa1424cd.png)
- hideable.json: add 'Page: Friends and (name of page)'
![hide-friends-and-page](https://user-images.githubusercontent.com/3022180/37274906-04940814-259b-11e8-8672-5fb812a2c671.jpg)