### PR TITLE
3 new hiders on Group pages

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -108,7 +108,7 @@
 		,{"id":182,"name":"Page Footer: Insights This Week","selector":"#pagelet_rhc_footer a[href$='/insights/']","parent":"._4-u2"}
 		,{"id":183,"name":"Left Col: Messenger Kids","selector":"#navItem_421935831521247"}
 		,{"id":184,"name":"Right Col: Suggested For You","selector":"#pagelet_video_home_suggested_for_you_rhc","parent":".pagelet"}
-		,{"id":185,"name":"Group Right Col: Add Members","selector":".groupRHCAddMemberTypeaheadBox"}
+		 {"id":185,"name":"Group Right Col: Add Members (name entry box)","selector":".groupRHCAddMemberTypeaheadBox"}
 		,{"id":186,"name":"Group Right Col: Member Count","selector":"a[href^='/groups/'][href$='/members/']", "parent": ".groupsRHCSectionHeader"}
 		,{"id":187,"name":"Group Right Col: Member Faces","selector":"#groupsRHCMembersFacepile"}
 		,{"id":188,"name":"Group Right Col: Welcome New Members","selector":"a[href*='/new_member_welcome/']", "parent": "._1-o8"}
@@ -175,5 +175,8 @@
 		,{"id":249,"name":"Group Post Feed: Search For Items","selector":"a[href^='/groups/'][href*='/for_sale_search/']","parent":"._4-u2"}
 		,{"id":250,"name":"Right Col: Unified Gaming Pagelet","selector":"#pagelet_games_unified_rhc"}
 		,{"id":251,"name":"Post: Choose friends to tag","selector":"._3ho0"}
+		,{"id":252,"name":"Group Right Col: Add Members (entire box)","selector":".groupRHCAddMemberTypeaheadBox", "parent":"._4-u2"}
+		,{"id":253,"name":"Group Right Col: Description","selector":"#groupsDescriptionBox"}
+		,{"id":254,"name":"Group Right Col: Create New Groups","selector":"a[ajaxify^='/ajax/groups/create_get/']", "parent":"._4-u2"}
 	]
 }


### PR DESCRIPTION
- hideable.json: add '(name entry box)' to 185 'Group Right Col: Add Members' name
![hide-group-add-members-entry](https://user-images.githubusercontent.com/3022180/41701318-e18b2f24-74e0-11e8-847d-8591a1815e80.png)
- hideable.json: add 252 'Group Right Col: Add Members (entire box)'
![hide-group-add-members-entire](https://user-images.githubusercontent.com/3022180/41701307-d7a50cc8-74e0-11e8-9126-bb5847574b1e.png)
- hideable.json: add 253 'Group Right Col: Description'
![hide-group-description](https://user-images.githubusercontent.com/3022180/41701325-e6356990-74e0-11e8-8984-a41790516595.png)
- hideable.json: add 254 'Group Right Col: Create New Groups'
![hide-group-create-new](https://user-images.githubusercontent.com/3022180/41701326-e8fb877c-74e0-11e8-9fe4-4cd399fa0958.png)