### PR TITLE
filters.json: temporarily disable 'commented on this' in 'Friend Activity'

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -277,7 +277,7 @@
 			"target": "action",
 			"operator": "matches",
 			"condition": {
-				"text": "(.*(commented on this|was mentioned in a post|was live| likes | liked |reacted to this|was tagged in|replied to a comment).*)"
+				"text": "(.*(commented on this-TEMPORARILY DISABLED|was mentioned in a post|was live| likes | liked |reacted to this|was tagged in|replied to a comment).*)"
 			}
 		}],
 		"actions": [{


### PR DESCRIPTION
It needs to be modified to match 'commented on this' but NOT
'(.*) commented on this. \1', i.e. person commenting on their
own post, as the combination of new improved envelope scraper +
FB enveloping almost all posts with comment wrappers causes it
to eliminate more than half of all posts.

This is a temporary measure until I can spend the time to figure
out the right way to craft that regex.