### PR TITLE
filters.json: make 'commented on this' not apply to self-comments

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -277,7 +277,7 @@
 			"target": "action",
 			"operator": "matches",
 			"condition": {
-				"text": "(.*(commented on this-TEMPORARILY DISABLED|was mentioned in a post|was live| likes | liked |reacted to this|was tagged in|replied to a comment).*)"
+				"text": "(.*(?:^(.*) commented on this\.(?:(?! \2 $).)*$|was mentioned in a post|was live| likes | liked |reacted to this|was tagged in|replied to a comment).*)"
 			}
 		}],
 		"actions": [{


### PR DESCRIPTION
This uses a negative lookahead regular expression, which I always have
terrible trouble with.  This seems to do the job, but -- will have to
see what users report.

It is specifically excluding 'Foo commented on this. Foo '; where the
precise construction of this with 'period space \1 space $' is an
artifact of how SFx constructs the 'Action' string from the text of
FB's HTML.  This is inherently fragile on several levels and will
likely require revisiting in response to various FB changes.  I
wouldn't be surprised to find it's *currently* broken by things like
'Foo commented on this. Foo shared his first post to the group Bar '.
Generally excluding 'Foo commented on this. .*Foo.*' would 'fix' that,
but there would be false matches, especially if 'Foo' is a one-word
name and others have that as their first or last name.

Truly fixing this stuff needs a much deeper semantic knowledge of the
'Action'.  What's truly wanted is 'IF (Action IS Commented-On) AND
(Comment-Actor-FB-ID == Original-Post-Actor-FB-ID), THEN Don't Filter'.
Which we're a very long way from.

Tagging for post-review, though I will push this immediately.