### PR TITLE
filters.json: 'Friend Activity' pass Person A's comments on Person A's 'share' posts

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -277,7 +277,7 @@
 			"target": "action",
 			"operator": "matches",
 			"condition": {
-				"text": "(.*(?:^(.*) commented on this\\.(?:(?! \\2 $).)*$|was mentioned in a post|was live| likes | liked |reacted to this|was tagged in|replied to a comment).*)"
+				"text": "(.*(?:^(.*) commented on this\\.(?:(?!.*\\2.*$).)*$|was mentioned in a post|was live| likes | liked |reacted to this|was tagged in|replied to a comment).*)"
 			}
 		}],
 		"actions": [{


### PR DESCRIPTION
Hmmm, I committed this locally and pushed, now having second thoughts:

Currently 'Friend Activity' does not specifically filter out 'shared' stuff.  Perhaps it should; but then I think it might filter out almost everything.  But to fulfill the 'which they didn't actually create' description clause, it really should.

In which case this patch is actually counter-productive.  It was in response to someone wishing that Person A commenting on their own post wouldn't be filtered -- which I did with the previous patch, regarding only posts initiated by Person A.  True 'status' posts.

This patch does make it more self-consistent by allowing through A's comments on A's share, as well as A's initial share.

Probably best solution is: yes put this patch in; and supply a second filter which filters all '.* shared .*' (including the ones suddenly allowed through by this patch).  Then people can control it all.

Not committing this myself.