### PR TITLE
hideable.json: add 259 'Blue Bar: Create'

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -277,7 +277,7 @@
 			"target": "action",
 			"operator": "matches",
 			"condition": {
-				"text": "(.*(?:^(.*) commented on this\\.(?:(?!.*\\2.*$).)*$|was mentioned in a post|was live| likes | liked |reacted to this|was tagged in|replied to a comment).*)"
+				"text": "(.*(?:^(.*) commented on this\\.(?:(?! \\2 $).)*$|was mentioned in a post|was live| likes | liked |reacted to this|was tagged in|replied to a comment).*)"
 			}
 		}],
 		"actions": [{

--- a/filters.json
+++ b/filters.json
@@ -277,7 +277,7 @@
 			"target": "action",
 			"operator": "matches",
 			"condition": {
-				"text": "(.*(?:^(.*) commented on this\\.(?:(?! \\2 $).)*$|was mentioned in a post|was live| likes | liked |reacted to this|was tagged in|replied to a comment).*)"
+				"text": "(.*(?:^(.*) commented on this\\.(?:(?!.*\\2.*$).)*$|was mentioned in a post|was live| likes | liked |reacted to this|was tagged in|replied to a comment).*)"
 			}
 		}],
 		"actions": [{

--- a/hideable.json
+++ b/hideable.json
@@ -182,5 +182,6 @@
 		,{"id":256,"name":"Left Col: Business Discovery","selector":"#navItem_151408195724475"}
 		,{"id":257,"name":"Right / Far Right Col: (Games) Trending Among Friends","selector":"div[data-games-xout-query-type='gyml-trending-among-friends']"}
 		,{"id":258,"name":"Chat: Facebook Messages online list / settings (entry box when zoomed out)","selector":"#pagelet_sidebar .fbChatTypeahead"}
+		,{"id":259,"name":"Blue Bar: Create","selector":"#creation_hub_entrypoint","parent":"._4kny"}
 	]
 }


### PR DESCRIPTION
Unfortunately this is another one where the hider is offset from the item.  But it does work.

![hide-create](https://user-images.githubusercontent.com/3022180/42666312-2d1024d0-85f9-11e8-8540-befc986c5c63.png)

I've been poking around trying to figure out the offsetting problem.  So far no joy, but I expect I'll get there and eventually a later version of SFx will correctly emplace all of the offset ones, without requiring change to hideable.json.  Providing the capability now -- despite the potential for confusion.