### PR TITLE
tweaks.json: re-enable and fix 'Remove Status Background Colors'

### DIFF
--- a/tweaks.json
+++ b/tweaks.json
@@ -24,7 +24,7 @@
 			"id" : 7,
 			"title": "Remove Status Background Colors",
 			"description": "Facebook recently introduced a feature to allow users to select a background color for their status updates. This tweak removes the background and returns the posts to normal.",
-			"css": "[XXXsfx_post] [data-ft*='\"K\"'] div[style*=\"background-\"] {\n  background-image:none !important;\n  background-color:inherit !important;\n}\n\n[XXXsfx_post] [data-ft*='\"K\"'] div[style*=\"background-\"] span[style*=\"color\"][role=\"presentation\"] {\n  visibility:visible !important;\n  color:inherit !important;\n  font-size:inherit !important;\n  line-height:inherit !important;\n  font-weight:inherit !important;\n  text-align:left !important;\n  padding:0px 12px !important;\n}\n\n[XXXsfx_post] [data-ft*='\"K\"'] div[style*=\"background-\"] span[style*=\"padding-top\"] {\n  padding-top:0 !important;\n}\n\n[XXXsfx_post] [data-ft*='\"K\"'] div[style*=\"background-\"] span[style*=\"color\"]:not([role=\"presentation\"]) {\n  display:none !important;\n}"
+			"css": "[sfx_post] [data-ft*='\"K\"'] div[style*=\"background-\"] {\n  background-image:none !important;\n  background-color:inherit !important;\n  min-height:inherit !important;\n}\n\n[sfx_post] [data-ft*='\"K\"'] div[style*=\"background-\"] span[style*=\"color\"] {\n  visibility:visible !important;\n  color:inherit !important;\n  font-size:inherit !important;\n  line-height:inherit !important;\n  font-weight:inherit !important;\n  text-align:left !important;\n  padding:0px 12px !important;\n}\n\n[sfx_post] [data-ft*='\"K\"'] div[style*=\"background-\"] span[style*=\"padding-top\"] {\n  padding-top:0 !important;\n}"
 		}
 	]
 }


### PR DESCRIPTION
See [facebook.com/1855138757904199](https://facebook.com/1855138757904199) for discussion & links.

I will merge this in about a day if no objections.  It will re-activate the feature for people who didn't already disable or remove the subscription tweak; we'll need to post an announcement that it's back, for people who did.

Example original post:
![status-background-1](https://user-images.githubusercontent.com/3022180/43998539-89d19904-9dac-11e8-8f7c-fd93267b6b4b.png)


Appearance with previous 'Remove Status Background Colors' tweak after recent FB HTML change:
![status-background-2](https://user-images.githubusercontent.com/3022180/43998540-8c5784ae-9dac-11e8-8efe-4242645bdb62.png)


Appearance with updated tweak:
![status-background-3](https://user-images.githubusercontent.com/3022180/43998541-8ecdc0d6-9dac-11e8-9ed9-8b376ec8275a.png)


