### PR TITLE
filters.json: update 'Hide "Shared Memories"' to match current FB HTML

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -234,7 +234,7 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "a[href=\"/onthisday/?source=shared_feed_story\"]"
+				"text": "a[href*='/onthisday/'][href*='shared_feed_story']"
 			}
 		}],
 		"actions": [{


### PR DESCRIPTION
What used to be '\<a href="/onthisday/?source=shared_feed_story">' is now '\<a href="/onthisday/?source=shared_feed_story&three_miles_of_gibberish">'.  Trying to make it more resilient.

I don't want to just match '/onthisday/' as users might inject such a link in a discussion about FB behavior; or it might be a completely unrelated link to some other web page which just happens to use that simple phrase in its URL.