### PR TITLE
More work on 'Sponsored (Experimental)'

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -27,7 +27,13 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": ".userContentWrapper>div div>span>span:contains(^Suggested Post$)"
+				"text": "a.c_1j1_sdpxqd:not(.d_1j1_sdpa56)"
+			}
+		}, {
+			"target": "any",
+			"operator": "contains_selector",
+			"condition": {
+				"text": "a._5pcq[ajaxify*='ad_id=']"
 			}
 		}, {
 			"target": "any",
@@ -45,49 +51,23 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "a._5pcq[ajaxify*='ad_id=']"
-			}
-		}, {
-			"target": "any",
-			"operator": "contains_selector",
-			"condition": {
 				"text": "a[href*='/business/help/']:contains(^Paid)"
 			}
-		}],
-		"actions": [{
-			"action": "hide",
-			"tab": "sponsored.0909.A",
-			"show_note": true,
-			"custom_note": "Sponsored Post hidden (Experimental 0909.A)! Click to show/hide this ad."
-		}],
-		"title": "Sponsored/Suggested Posts (Experimental 2018-09-09 part A)",
-		"description": "please place BEFORE existing Sponsored filter(s)"
-	}, {
-		"id": 25,
-		"match": "ALL",
-		"configurable_actions": true,
-		"stop_on_match": true,
-		"rules": [{
-			"target": "any",
-			"operator": "contains_selector",
-			"condition": {
-				"text": "h5 span.fcg a[data-hovercard*='/page.php']"
-			}
 		}, {
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "h5 span.fcg:contains(\\blikes{0,1}\\b)"
+				"text": ".userContentWrapper>div div>span>span:contains(^Suggested Post$)"
 			}
 		}],
 		"actions": [{
 			"action": "hide",
-			"tab": "sponsored.0909.B",
+			"tab": "sponsored.0910",
 			"show_note": true,
-			"custom_note": "Sponsored Post hidden (Experimental 0909.B)! Click to show/hide this ad."
+			"custom_note": "Sponsored Post hidden (Experimental 0910)! Click to show/hide this ad."
 		}],
-		"title": "Sponsored/Suggested Posts (Experimental 2018-09-09 part B)",
-		"description": "please place immediately AFTER part A"
+		"title": "Sponsored/Suggested Posts (Experimental 2018-09-10)",
+		"description": "please place BEFORE existing Sponsored filter(s)"
 	}, {
 		"id": 2,
 		"match": "ALL",


### PR DESCRIPTION
filters.json: make 23 'Sponsored (Experimental)' a single filter again
filters.json: add a new powerful expression to 23 'Sponsored (Experimental)'
filters.json: order 23's expressions most-to-least successful

Besides improving ad filtering, hopefully this will get by the github
pages build process.  It emailed me that the build failed, with no
details, and I couldn't find them on github.com either; attempting to
build locally with 'Jekyll' failed utterly.  But I think it was
something about the quoting of '\b', and that's gone now.