### PR TITLE
closing in on a working set of ad filters

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -27,12 +27,6 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "a.c_1j1_sdpxqd:not(.d_1j1_sdpa56)"
-			}
-		}, {
-			"target": "any",
-			"operator": "contains_selector",
-			"condition": {
 				"text": "a._5pcq[ajaxify*='ad_id=']"
 			}
 		}, {
@@ -68,6 +62,32 @@
 		}],
 		"title": "Sponsored/Suggested Posts (Experimental 2018-09-10)",
 		"description": "please place BEFORE existing Sponsored filter(s)"
+	}, {
+		"id": 25,
+		"match": "ALL",
+		"configurable_actions": true,
+		"stop_on_match": true,
+		"rules": [{
+			"target": "any",
+			"operator": "contains_selector",
+			"condition": {
+				"text": "h5 span.fcg a[data-hovercard*='/page.php']"
+			}
+		}, {
+			"target": "any",
+			"operator": "contains_selector",
+			"condition": {
+				"text": "h5 span.fcg:contains( +likes{0,1} +)"
+			}
+		}],
+		"actions": [{
+			"action": "hide",
+			"tab": "sponsored.0910.B",
+			"show_note": true,
+			"custom_note": "Sponsored Post hidden (Experimental 0910.B)! Click to show/hide this ad."
+		}],
+		"title": "Sponsored/Suggested Posts (Experimental 2018-09-10 part B)",
+		"description": "please place right AFTER the main Experimental 0910 filter"
 	}, {
 		"id": 2,
 		"match": "ALL",


### PR DESCRIPTION
filters.json: remove FB-acct-specific code from 23 'Sponsored (Experimental)'
filters.json: reinstate 25 'Sponsored (Experimental) part B'

-- as part A's best filter turns out to be FB-account-specific.

The two 'Experimental' filters together should be ~95% effective.