### PR TITLE
filters.json: add '._42b7' expression to 25 'Sponsored (Experimental)'

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -27,6 +27,12 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
+				"text": ".userContentWrapper ._42b7"
+			}
+		}, {
+			"target": "any",
+			"operator": "contains_selector",
+			"condition": {
 				"text": "a._5pcq[ajaxify*='ad_id=']"
 			}
 		}, {


### PR DESCRIPTION
This tags the 'Like Page' button in Sponsored posts but nothing else,
AFAICT.  It will break soon, but it's effective right now.