### PR TITLE
filters.json: 2018-09-29 edition of 23 & 25 'Sponsored (Experimental)' parts A & B

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -27,6 +27,24 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
+				"text": "s a[role='link'] span > span:contains(^.$)"
+			}
+		}, {
+			"target": "any",
+			"operator": "contains_selector",
+			"condition": {
+				"text": "a._5pcq span:contains(^Sponsored)"
+			}
+		}, {
+			"target": "any",
+			"operator": "contains_selector",
+			"condition": {
+				"text": "a._42ft:contains(^(Download|Get Offer|!-Learn More-!|Shop Now|Sign Up)$)"
+			}
+		}, {
+			"target": "any",
+			"operator": "contains_selector",
+			"condition": {
 				"text": "a._5pcq[ajaxify*='ad_id=']"
 			}
 		}, {
@@ -68,11 +86,11 @@
 		}],
 		"actions": [{
 			"action": "hide",
-			"tab": "sponsored.0915.A",
+			"tab": "sponsored.0929.A",
 			"show_note": true,
-			"custom_note": "Sponsored Post hidden (Experimental 0915.A)! Click to show/hide this ad."
+			"custom_note": "Sponsored Post hidden (Experimental 0929.A)! Click to show/hide this ad."
 		}],
-		"title": "Sponsored/Suggested Posts (Experimental 2018-09-15 part A)",
+		"title": "Sponsored/Suggested Posts (Experimental 2018-09-29 part A)",
 		"description": "please place BEFORE existing Sponsored filter(s)"
 	}, {
 		"id": 25,
@@ -94,12 +112,12 @@
 		}],
 		"actions": [{
 			"action": "hide",
-			"tab": "sponsored.0915.B",
+			"tab": "sponsored.0929.B",
 			"show_note": true,
-			"custom_note": "Sponsored Post hidden (Experimental 0915.B)! Click to show/hide this ad."
+			"custom_note": "Sponsored Post hidden (Experimental 0929.B)! Click to show/hide this ad."
 		}],
-		"title": "Sponsored/Suggested Posts (Experimental 2018-09-15 part B)",
-		"description": "please place right AFTER the main Experimental 0915 filter"
+		"title": "Sponsored/Suggested Posts (Experimental 2018-09-29 part B)",
+		"description": "please place right AFTER the main Experimental 0929 filter"
 	}, {
 		"id": 2,
 		"match": "ALL",


### PR DESCRIPTION
    - add three new expressions (details below)
    - update the names so people will clearly see they've been updated
    - these are stopgap measures until a new SFx release can be gotten out
    - waiting on PR#137 :hid-within() to be committed

This adds the following CSS matches to the previous (2018-09-15) 'part A' filter:

(1) s a[role='link'] span:contains(^.$)

This matches most Sponsored posts, catching the 'S' of 'SpSonSsoSred'.
The intermingled 'S'es are individual spans.  In other languages they
are the first letter of that language's word for 'Sponsored', so should
still match (not sure what happens if that 'letter' is some sort of
non-ASCII UNICODE).  BUT, this relies on the entire 'Sponsored' block
being inside an \<s> tag, which is surely a bug they will soon correct.
Regular posts have the same exact structure inside a \<span>.  In
Sponsored posts the 'S'es are hidden with CSS, while in regular posts
the entire string is hidden with CSS.

(2) a._5pcq span:contains(^Sponsored)

This matches a few ads (mostly political ads with the additional 'Paid'
span) which do not yet have the 'SpSonSsoSred' structure.

(3) a._42ft:contains(^(Download|Get Offer|!-Learn More-!|Shop Now|Sign Up)$)

Discovered by Ruth Kuryla, this matches little boxes which currently
appear in almost all Sponsored posts.

'Learn More' is intentionally commented out, despite being the most
common one, because I saw it appear in a regular post.  Not *really*
a regular post, it was a post probably generated by a web page on the
user's behalf, a 'vote' for an entity in a 'best of our city' contest;
but it did not tag itself 'Sponsored' and my judgment is that this
was a post expressing my friend's opinion, even if deeply tied into a
commercial activity, thus should NOT be filtered.

These three are currently catching 100% of my Sponsored posts; I'm
leaving the rest of the expressions intact as 'belt and suspenders'.
Hopefully we will ship :hid-within() soon, which will replace (1) above
with a more reliable expression.