### PR TITLE
improve 'Instant Games' hiders

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -167,8 +167,8 @@
 		,{"id":241,"name":"Right Col: Recently Viewed on Marketplace","selector":"#pagelet_marketplace_recently_viewed_rhc"}
 		,{"id":242,"name":"Right Col: Still Available on Marketplace","selector":"#pagelet_marketplace_bsg_recently_viewed_rhc"}
 		,{"id":243,"name":"Right Col: Featured on Facebook Watch","selector":"#pagelet_video_home_promotion_rhc"}
-		,{"id":244,"name":"Right / Far Right Col: Instant Games","selector":"div[data-games-xout-query-type='instant-games']"}
-		,{"id":245,"name":"Right / Far Right Col: Games Your Friends Play","selector":"div[data-games-xout-query-type='instant-games-your-friends-play']"}
+		,{"id":244,"name":"Right / Far Right Col: Instant Games","selector":"div[data-games-xout-query-type^='instant-games']"}
+		,{"id":245,"name":"retired","selector":"retired#retired"}
 		,{"id":246,"name":"Post: Recommend a place","selector":"[sfx_post] ._5ofu._1xap"}
 		,{"id":247,"name":"Right / Far Right Col: Your Games","selector":"div[data-games-xout-query-type='gyml-game-bookmarks']"}
 		,{"id":248,"name":"Group Right Col: Upcoming Group Events","selector":"._4-u3 a[href^='/groups/'][href$='/events/']","parent":"._4-u2"}


### PR DESCRIPTION
- hideable.json: make 244 'Instant Games' cover all related type of game
block (they all look the same anyway)

- hideable.json: retire 245 'Games Your Friends Play', a subtype of
'Instant Games'.  Needs to be retired as otherwise two hiders would
select the same element, with I'm not sure what consequences