### PR TITLE
filters.json: some IDs are now 'feed_sub_title' and other such variants

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -91,7 +91,7 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": ".timestampContent:hidden-within([id*='feed'][id*='subtitle'])"
+				"text": ".timestampContent:hidden-within([id*='eed'][id*='itle'])"
 			}
 		}, {
 			"target": "any",


### PR DESCRIPTION
Lots of users reporting posts starting to leak through.  Several have sent me HTML of leakthroughs, which I haven't had time to look at yet.  But I saw about this on https://github.com/uBlockOrigin/uAssets/issues/3367#issuecomment-441464332, and it would obviously cause the problem, so I issue this now, look at details later.