### PR TITLE
hideable.json: rename 227 as 'Group: New Group Feature Announcements'…

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -150,7 +150,7 @@
 		,{"id":224,"name":"Right Col: Pages Liked By Page Secondary pagelet","selector":"div[id^='PagePagesLikedByPageSecondaryPagelet_']"}
 		,{"id":225,"name":"Right Col: Related Pages Secondary pagelet","selector":"div[id^='PageRelatedPagesSecondaryPagelet_']"}
 		,{"id":226,"name":"Right Col: Popular Shares pagelet","selector":"div[id^='PagePopularSharesPagelet_']"}
-		,{"id":227,"name":"Group: Wondering Who's Here?","selector":"._390x","parent":"._4-u2"}
+		,{"id":227,"name":"Group: New Group Feature Announcements","selector":"._390x","parent":"._4-u2"}
 		,{"id":228,"name":"Post: Show more information about this article (NOTE: OPEN A SINGLE POST IN A NEW TAB BEFORE USING THIS!  See http://tiny.cc/sfx-h228)","selector":"a[ajaxify*='/article_context/']","parent":"[data-hover]"}
 		,{"id":229,"name":"Left Col: Greetings","selector":"#navItem_1157621394365930"}
 		,{"id":230,"name":"Blue Bar: Account Switcher","selector":"._33s3","parent":"._4kny"}


### PR DESCRIPTION
… since that's what it is.  I don't think we can distinguish them more finely without a :contains()-like selector

(For instance, could look for particular image URLs in the contents; but those are extremely ephemeral, so it would fail.)

Currently known to hide what I would individually tag as:

- Group: Wondering Who's Here?
- Group: New Conversation Starter Badge
- Group: Help Grow This Group

and clearly will continue to hide future Group new-feature announcements until FB change the CSS...