### PR TITLE
hideable.json: 26 'Sponsored part C' show poster name in hidden-post msgs

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -71,7 +71,7 @@
 			"target": "page",
 			"operator": "matches",
 			"condition": {
-				"text": "."
+				"text": "(.{1,50})"
 			}
 		}, {
 			"target": "any",
@@ -90,11 +90,11 @@
 			"action": "hide",
 			"tab": "sponsored.2019.C",
 			"show_note": true,
-			"custom_note": "Sponsored Post hidden (Experimental 2019.C)! Click to show/hide this ad."
+			"custom_note": "Sponsored.2019.C: click to show/hide '$1'."
 		}],
 		"configurable_actions": true,
-		"title": "Sponsored/Suggested Posts (Experimental 2019-02-03 part C)",
-		"description": "please place before main 2019-02-03 filter; parts A & B totally optional",
+		"title": "Sponsored/Suggested Posts (Experimental part C, 2019-02-15)",
+		"description": "order between Sponsored filters not important; parts A/B/OLD are optional",
 		"stop_on_match": true
 	}, {
 		"id": 2,


### PR DESCRIPTION
Image is of my 'Sponsored' tab, with 'Show posts marked Read' enabled -- 4 posts are unread, 3 are read (bottom border of last one is missing for some reason...)

![image](https://user-images.githubusercontent.com/3022180/52888976-d13be500-3132-11e9-896c-72eb502d5b53.png)