### PR TITLE
hideable.json: fix matching in 'Post Header: xyz Badge' hiders 279/280/304/305

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -202,8 +202,8 @@
 		,{"id":276,"name":"Left Col: 2018 Election","selector":"#navItem_300526153719870"}
 		,{"id":277,"name":"Right Col: Games you might like","selector":"div[data-ego-fbid][data-gt*='games_ego'] a[href*='/games/']","parent":"._4-u2"}
 		,{"id":278,"name":"Right Col: Today's Games","selector":"#live_games_rhc"}
-		,{"id":279,"name":"Post Header: Conversation Starter Badge","selector":"a[href^='/groups/'][href*='ACTIVE_MEMBER']"}
-		,{"id":280,"name":"Post Header: New Member Badge","selector":"a[href^='/groups/'][href*='NEW_MEMBER']"}
+		,{"id":279,"name":"Post Header: Conversation Starter Badge","selector":"a[href*='/groups/'][href*='ACTIVE_MEMBER']"}
+		,{"id":280,"name":"Post Header: New Member Badge","selector":"a[href*='/groups/'][href*='NEW_MEMBER']"}
 		,{"id":281,"name":"News Feed: Mentorship ad for admins","selector":"#pagelet_megaphone a[href*='mentorship_option']","parent":"#pagelet_megaphone"}
 		,{"id":282,"name":"Friend Finder: People You May Know","selector":"#fbSearchResultsBox._30d"}
 		,{"id":283,"name":"Blue Bar: Friend Requests: People You May Know","selector":"#pagelet_bluebar .fbRequestList ~ ._3nzq"}
@@ -227,7 +227,7 @@
 		,{"id":301,"name":"Post: More From (name of Page)","selector":"._7gg2 ~ div .uiList","parent":"._4-u2"}
 		,{"id":302,"name":"News Feed: Discover Members","selector":"[sfx_post] ul a[ajaxify^='/groups/member_bio/']","parent":"[sfx_post]"}
 		,{"id":303,"name":"Right Col: Sponsored Pagelet (4)","selector":".ego_unit[data-ego-service] a [title] strong","parent":".pagelet"}
-		,{"id":304,"name":"Post Header: Rising Star Badge","selector":"a[href^='/groups/'][href*='RISING_STAR']"}
-		,{"id":305,"name":"Post Header: Visual Storyteller Badge","selector":"a[href^='/groups/'][href*='VISUAL_STORYTELLER']"}
+		,{"id":304,"name":"Post Header: Rising Star Badge","selector":"a[href*='/groups/'][href*='RISING_STAR']"}
+		,{"id":305,"name":"Post Header: Visual Storyteller Badge","selector":"a[href*='/groups/'][href*='VISUAL_STORYTELLER']"}
 	]
 }


### PR DESCRIPTION
Was matching on `a[href^='/groups/']`, now encountering some badges which are instead `a[href^='https://www.facebook.com/groups/']` -- better use `a[href*='/groups/']`.