### PR TITLE
hideable.json: update 199 'News Feed: Stories' to not have a parent

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -122,7 +122,7 @@
 		,{"id":196,"name":"Right Col: Instant Games","selector":"#pagelet_instant_games_rhc"}
 		,{"id":197,"name":"Right Col: What Your Friends Are Watching","selector":"#pagelet_video_home_friends_watching_rhc"}
 		,{"id":198,"name":"Right Col: Sponsored Pagelet (3)","selector":"a[href*='/ad_campaign/'],a[href*='paid-social'],a[data-gt*='ad_account_id']","parent":".pagelet"}
-		,{"id":199,"name":"News Feed: Stories","selector":"#stories_pagelet_below_composer"}
+		,{"id":199,"name":"News Feed: Stories","selector":"#stories_pagelet_below_composer","parent":0}
 		,{"id":200,"name":"Right Col: Reminders: Events","selector":"#event_reminders_link,a[href*='/events/']","parent":".fbRemindersStory"}
 		,{"id":201,"name":"Right Col: Reminders: Birthdays","selector":"a[ajaxify*='/birthday/']","parent":".fbRemindersStory"}
 		,{"id":202,"name":"Right Col: Reminders: Games","selector":"form[action*='/games/']","parent":".fbRemindersStory"}


### PR DESCRIPTION
Although I can find no history of this, my saved settings have #199 with
"parent: .mtm", which is wrong; and users are reporting trouble with
this hider, so I think they somehow have the same thing.  (#149 is
the only hider which has ever actually had '.mtm'; no idea how it got
transposed onto #199.)

To override this, put a zero value, which is read by the code as 'no
parent', but will cause retrieve_item_subscriptions() to erase '.mtm'.
(I will fix retrieve_item_subscriptions() later...)