### PR TITLE
filters.json: add selectors to 28 'Sponsored v24'

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -62,7 +62,13 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": ".uiStreamSponsoredLink,._5pcr a._34k6[ajaxify*='branded_content']"
+				"text": ".uiStreamSponsoredLink,._5pcr ._5-sh,._5pcr a._34k6[ajaxify*='branded_content'],._5pcr a._34k6[ajaxify*='/verified_voice_context/']"
+			}
+		}, {
+			"target": "any",
+			"operator": "contains_selector",
+			"condition": {
+				"text": "._5pcr ._3nlk,._5pbw a,._5pbw~a:contains(^Sponsored)"
 			}
 		}, {
 			"target": "any",


### PR DESCRIPTION
These catch a fraction of ads, will imperfectly help while the main
has-visible-text() filter is currently outraced:

- ._5pcr ._5-sh
- ._5pcr a._34k6[ajaxify*='/verified_voice_context/']"
- ._5pcr ._3nlk,._5pbw a,._5pbw~a:contains(^Sponsored)

The last one applies ':contains()' to all 3 selectors, an intentional
use of SFx's weak CSS parsing -- properly should need to be:

  ._5pcr ._3nlk:contains(^Sponsored),
  ._5pbw a:contains(^Sponsored),
  ._5pbw~a:contains(^Sponsored)