### PR TITLE
hideable.json: add 312 'Nub: Keyboard Shortcut Help'

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -235,5 +235,6 @@
 		,{"id":309,"name":"Left Col: Liked Pages","selector":"#navItem_250100865708545"}
 		,{"id":310,"name":"Post: Add this photo to your story?","selector":"[data-onclick*='add_to_story']","parent":"._1kyo"}
 		,{"id":311,"name":"Post: Ask Your Community for Support","selector":"[href*='/fundraiser/with_presence/create_dialog/']","parent":"._1s31"}
+		,{"id":312,"name":"Nub: Keyboard Shortcut Help","selector":"a.fbNubButton[aria-label=Keyboard Shortcut Help']"}]}
 	]
 }


### PR DESCRIPTION
This appears right next to / overlapping 22 'Chat: Facebook Messages pop-under conversations'; can't be helped with current tools.

When nub is hidden, kbd help still appears when hit '?', as a floating box not connected to the bottom rail.

![hide-keyboard-shortcut-help](https://user-images.githubusercontent.com/3022180/64758089-a78c4600-d4e8-11e9-9e0b-099cd42f84a6.png)
