### PR TITLE
filters.json: 28 'Sponsored' remove overly aggressive clause

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -68,12 +68,6 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "._5pcr ._3nlk,._5pbw a,._5pbw~a:contains(^(Спонз|Спонс|Được|Gespons|Patrocin|Реклам|Publicid|Spons|Chart|Sponz|Χορηγ|広告|贊助|赞助))"
-			}
-		}, {
-			"target": "any",
-			"operator": "contains_selector",
-			"condition": {
 				"text": "._5pbw a[href^='/a'][href*='/ads'][href*='/about'],._5pbw~a[href^='/a'][href*='/ads'][href*='/about'],._5pbw~* a[href^='/a'][href*='/ads'][href*='/about']"
 			}
 		}],


### PR DESCRIPTION
The '._5pbw a ... Spons' clause was mistakenly catching user / Group /
Page names starting with 'Spons', 'Chart', or any of the other-language
ad keywords.

Removing this clause will make the filter slightly weaker; but only a
small sub-class of ads were responsive to this clause in the 1st place.

Re: fb.com/2485097014892498

I may reinstate later with more specific class path, after further
research / observation.