### PR TITLE
Marketplace & Page Owner hideables

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -241,5 +241,29 @@
 		,{"id":315,"name":"Group Right Col: Categorize Posts / Create Topic","selector":"#group_rhc_post_tags_list"}
 		,{"id":316,"name":"Left Col: COVID-19 Information Center","selector":"#navItem_474171183259175"}
 		,{"id":317,"name":"Left Col: Live Videos","selector":"#navItem_1472579752766895"}
+		,{"id":318,"name":"Marketplace Post: Information about Covid-19 for buyers and sellers","selector":".userContent ~ ._717p a[href*='/covid']","parent":"._717p"}
+		,{"id":319,"name":"Page Owner: Composer Bar","selector":"#PagesComposerConsolidatedEntry"}
+		,{"id":320,"name":"Page Owner: Invite friends to like your Page","selector":"#PagesProfileHomeSecondaryColumnPagelet [href*='/friend_inviter']","parent":"._4-u2"}
+		,{"id":321,"name":"Page Owner: Our Story","selector":"#PagesProfileHomeSecondaryColumnPagelet [aria-label='Our Story']","parent":"._4-u2"}
+		,{"id":322,"name":"Page Owner: various reach / boost options","selector":"#PagesProfileHomePrimaryColumnPagelet ._1td8"}
+		,{"id":323,"name":"Page Owner: Get Started With Automated Ads","selector":"#PagesProfileHomePrimaryColumnPagelet ._6vhx"}
+		,{"id":324,"name":"Page Owner: ads-n-reach box","selector":"#PagesProfileHomePrimaryColumnPagelet ._6vhx","parent":"._4-u2"}
+		,{"id":325,"name":"Page Owner: Set Up FAQs","selector":"#pageMessagingTipCard ._hjq"}
+		,{"id":326,"name":"Page Owner: Set Up FAQ answers","selector":"#pageMessagingTipCard ._hjf"}
+		,{"id":327,"name":"Page Owner: Page Timeline Create Page","selector":"[id^=PageTimelineCreatePagePagelet]"}
+		,{"id":328,"name":"Page Owner: Page Fundraiser Campaigns","selector":"[id^=PageFundraiserCampaignsPagelet]"}
+		,{"id":329,"name":"Page Owner: Page People","selector":"[id^=PagePeoplePagelet]"}
+		,{"id":330,"name":"Page Owner: Page Review Needy Place Card","selector":"[id^=PageReviewNeedyPlaceCardPagelet]"}
+		,{"id":331,"name":"Page Owner: Page Locations","selector":"[id^=PageLocationsPagelet]"}
+		,{"id":332,"name":"Page Owner: Page Photos Container","selector":"[id^=PagePhotosContainerPagelet]"}
+		,{"id":333,"name":"Page Owner: Page Videos","selector":"[id^=PageVideosPagelet]"}
+		,{"id":334,"name":"Page Owner: Page Notes Container","selector":"[id^=PageNotesContainerPagelet]"}
+		,{"id":335,"name":"Page Owner: Page Reviews Container","selector":"[id^=PageReviewsContainerPagelet]"}
+		,{"id":336,"name":"Page Owner: Page Places People Also Visited Secondary","selector":"[id^=PagePlacesPeopleAlsoVisitedSecondaryPagelet]"}
+		,{"id":337,"name":"Page Owner: Page Related Pages Secondary","selector":"[id^=PageRelatedPagesSecondaryPagelet]"}
+		,{"id":338,"name":"Page Owner: Page Graph Search","selector":"[id^=PageGraphSearchPagelet]"}
+		,{"id":339,"name":"Page Owner: Page Pages Liked By Page Secondary","selector":"[id^=PagePagesLikedByPageSecondaryPagelet]"}
+		,{"id":340,"name":"Page Owner: Pages Suggested By Page Secondary","selector":"[id^=PagesSuggestedByPageSecondaryPagelet]"}
+		,{"id":341,"name":"Page Owner: Page SEO Interlinking Related Element","selector":"[id^=PageSEOInterlinkingRelatedElementPagelet]"}
 	]
 }


### PR DESCRIPTION
hideable.json: add 318 'Marketplace Post: Information about Covid-19 for buyers and sellers' ([fb.com/246970563375495](https://fb.com/246970563375495))

![market-19](https://user-images.githubusercontent.com/3022180/80083793-d94b9d80-850a-11ea-8fde-579bda10b7e9.png)

hideable.json: add 319-341, items on a Page owner's display ([fb.com/246423846763500](https://fb.com/246423846763500)):

![page-owner](https://user-images.githubusercontent.com/3022180/80083821-e4063280-850a-11ea-97c2-c897b355c5fe.png)

319 'Page Owner: Composer Bar'
320 'Page Owner: Invite friends to like your Page'
321 'Page Owner: Our Story'
322 'Page Owner: various reach / boost options'
323 'Page Owner: Get Started With Automated Ads'
324 'Page Owner: ads-n-reach box'
325 'Page Owner: Set Up FAQs'
326 'Page Owner: Set Up FAQ answers'
327-* 'Page Owner: Page Timeline Create Page'
328-* 'Page Owner: Page Fundraiser Campaigns'
329-* 'Page Owner: Page People'
330-* 'Page Owner: Page Review Needy Place Card'
331-* 'Page Owner: Page Locations'
332-* 'Page Owner: Page Photos Container'
333-* 'Page Owner: Page Videos'
334-* 'Page Owner: Page Notes Container'
335-* 'Page Owner: Page Reviews Container'
336-* 'Page Owner: Page Places People Also Visited Secondary'
337-* 'Page Owner: Page Related Pages Secondary'
338-* 'Page Owner: Page Graph Search'
339-* 'Page Owner: Page Pages Liked By Page Secondary'
340-* 'Page Owner: Pages Suggested By Page Secondary'
341-* 'Page Owner: Page SEO Interlinking Related Element'

'*' -- not seen onscreen, just in code; some may be obsolete, some may be future, no harm in scanning them once at Hide/Show time.