### PR TITLE
hideable.json: add 350 'Above Group Feed: Introducing Messenger Rooms for Groups'

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -273,5 +273,6 @@
 		,{"id":347,"name":"Chat Sidebar: More Contacts","selector":".fbChatOrderedList div:not(:first-of-type)._55ob,.fbChatOrderedList div[id] > ul:not(:first-of-type)"}
 		,{"id":348,"name":"Left Col: Facebook Pay","selector":"#navItem_2805739562851096"}
 		,{"id":349,"name":"Left Col: Lift Black Voices","selector":"#navItem_807767239627494"}
+		 {"id":350,"name":"Above Group Feed: Introducing Messenger Rooms for Groups","selector":"._8q_6 a._6ne8:not([href]) > div[aria-label] [dir=auto].q66pz984.jq4qci2q.a3bd9o3v","parent":"[role=article]"}
 	]
 }


### PR DESCRIPTION
This selector might not be specific.  I've seen the targeted area used
for 2 different things; the other was today, about a video about racial
injustice.  This selector distinguishes between those two, but might
pick up any other top-of-news-feed splash they add which lacks an href
(the video had an href).  The 3 newest-style classes I'm selecting on
are the ones that seem most specific to *this* presentation, thus least
likely to be repeated on some other use of the area.

I'm not using the hider myself, instead have a dashed border CSS to
keep an eye on it.  If I see something else highlighted I'll be able to
either fix this, or abolish it if I can't make a sufficiently specific
hider.