### PR TITLE
Video & Voice call buttons for pop-under & full-page chat

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -275,6 +275,9 @@
 		,{"id":349,"name":"Left Col: Lift Black Voices","selector":"#navItem_807767239627494"}
 		,{"id":350,"name":"Above Group Feed: Introducing Messenger Rooms for Groups","selector":"._8q_6 a._6ne8:not([href]) > div[aria-label] [dir=auto].q66pz984.jq4qci2q.a3bd9o3v","parent":"[role=article]"}
 		,{"id":351,"name":"Post Comments: Facebook comment quality survey","selector":"form.commentable_item ._7mtf"}
+		,{"id":352,"name":"Chat Pop-Under: 'Start Voice Call' button","selector":"#ChatTabsPagelet ._1iti [data-testid*=Voice]"}
+		,{"id":353,"name":"Chat Pop-Under: 'Start Video Call' button","selector":"#ChatTabsPagelet ._1iti [data-testid*=Video]"}
+		,{"id":354,"name":"Messages: 'Start Voice Call' button","selector":"#content ._6ynl [data-testid*=Voice]"}
+		,{"id":355,"name":"Messages: 'Start Video Call' button","selector":"#content ._6ynl [data-testid*=Video]"}
 	]
 }
-


### PR DESCRIPTION
hideable.json: add 352 "Chat Pop-Under: 'Start Voice Call' button"
hideable.json: add 353 "Chat Pop-Under: 'Start Video Call' button"
hideable.json: add 354 "Messages: 'Start Voice Call' button"
hideable.json: add 355 "Messages: 'Start Video Call' button"

![hide-chat-popunder-voice-video](https://user-images.githubusercontent.com/3022180/87245465-5562cc80-c3fa-11ea-9fa4-c3ca34b08396.png)
![hide-messenger-voice-video](https://user-images.githubusercontent.com/3022180/87245467-5ac01700-c3fa-11ea-80fc-3fe285af3938.png)
