### PR TITLE
tweaks.json: update 3 'Hide Notification Bubble' to support 'new FB'

### DIFF
--- a/tweaks.json
+++ b/tweaks.json
@@ -9,7 +9,7 @@
 			"id" : 3,
 			"title" : "Hide Notification Bubble",
 			"description" : "When a new notification is added, it is displayed in the lower left corner. Enable this tweak to hide it.",
-			"css" : "ul[data-gt*=\"\\\"ref\\\":\\\"beeper\\\"\"] { display:none !important; }"
+			"css" : "ul[data-gt*=\"\\\"ref\\\":\\\"beeper\\\"\"], ul.poy2od1o.p7hjln8o > li.pmk7jnqg.pedkr2u6.ilcmz9jb.j9ispegn { display:none !important; }"
 		}, {
 			"id" : 5,
 			"title" : "Force Chat Popup To Default Colors",


### PR DESCRIPTION
On committing this, and when people's tweak update cycles complete, people who had lower left ephemeral notifications hidden on 'old FB' will have them hidden on 'new'.  We may hear some support questions about that...

The top of the notification structure is now:

<ul class="lfi1tu6t p7hjln8o poy2od1o re5koujm kavbgo14">

.lfi1tu6t { bottom:16px; }
.p7hjln8o { list-style:none; }
.poy2od1o { position:fixed; }
.re5koujm { left:16px; }
.kavbgo14 { z-index:2; }

<li class="pedkr2u6 g3zh7qmp pc15xi3s r5qslco7 ilcmz9jb q9uorilb pmk7jnqg j9ispegn" style="bottom: 0px;">

.pedkr2u6 { opacity:1; }
.g3zh7qmp { transform:scale(1); }
.pc15xi3s { transition-duration:var(--fds-duration-short-in); }
.r5qslco7 { transition-property:transform,opacity; }
.ilcmz9jb { transition-timing-function:var(--fds-animation-enter-exit-in); }
.q9uorilb { display:inline-block; }
.pmk7jnqg { position:absolute; }
.j9ispegn { left:0; }

The hider looks for a ul { position:fixed; list-style:none; }
containing an li { position:absolute; opacity:1; left:0;
transition-timing-function:var(--fds-animation-enter-exit-in); } --
this should be pretty unique to lower left notification popups.  And
relatively stable, though of course they could change styling of
anything at any time.