### PR TITLE
filters.json: update 28 'sponsored' for latest 'new FB' changes

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -79,13 +79,7 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "*[role='button']:has-visible-text(^(Sponsored|Спонз|Спонс|Được|Gespons|Hirdetés|Patrocin|Реклам|Publicid|Spons|Chart|Sponz|Χορηγ|広告|贊助|赞助|ממומ))"
-			}
-		}, {
-			"target": "any",
-			"operator": "contains_selector",
-			"condition": {
-				"text": "._5pcp,._5pcq:has-visible-text(^(Спонз|Спонс|Được|Gespons|Hirdetés|Patrocin|Реклам|Publicid|Spons|Chart|Sponz|Χορηγ|広告|贊助|赞助|ממומ))"
+				"text": "[role=button],[role=link],._5pcp,._5pcq:has-visible-text(^(Chart|Спонз|Спонс|Được|Gespons|Hirdetés|Patrocin|Реклам|Publicid|Spons|Sponz|Χορηγ|広告|贊助|赞助|ממומ))"
 			}
 		}, {
 			"target": "any",


### PR DESCRIPTION
Multiple users are reporting bursts of ads.  One showed me HTML in which
the UI language's 'Sponsored' word appeared in an <a role='link'> rather
than role='button'.  While it is likely this isn't the only change
needed, it's a step forward.

This also consolidates two selectors back to one.  The expression relies
on a fault in the SFx filter engine's CSS parsing enhancements.  Proper
CSS parsing would apply :has-visible-text() only to the immediately
preceding selector.  In reality, the entire string of alternating CSS
rules is evaluated first; then filtered by the :has-visible-text() rule.

The consolidation reduces double-processing of the regular expression
and differential drift of fixes over time (like the next item).

'Sponsored' is removed from the list of words, as it is handled by
'^(...|Spons|...)' further into the match string.  Moving a particularly
likely match to the head of the match alternation does not improve
performance.

'Chart' is moved into alphabetical order like the other words.