### PR TITLE
fix a false match in Sponsored filter

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -79,7 +79,7 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "[role=button],[role=link],._5pcp,._5pcq:has-visible-text(^(Chart|Спонз|Спонс|Được|Gespons|Hirdetés|Patrocin|Реклам|Publicid|Spons|Sponz|Χορηγ|広告|贊助|赞助|ממומ))"
+				"text": "[role=button],[role=link],._5pcp,._5pcq:has-visible-text(^(Chartered$|Спонз|Спонс|Được|Gespons|Hirdetés|Patrocin|Реклам|Publicid|Spons|Sponz|Χορηγ|広告|贊助|赞助|ממומ))"
 			}
 		}, {
 			"target": "any",


### PR DESCRIPTION
filters.json: 1 'Sponsored', change 'Chart' to 'Chartered$' to more precisely match the 'English (Pirate)' word for Sponsored -- was matching a link to a business 'Charting Creations'