### PR TITLE
hideable.json: fix Sponsored item hiders for real

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -344,13 +344,13 @@
 		,{"id":2021010434,"name":"Left Rail: Town Hall","selector":"[data-pagelet=page] [role=navigation] a[href*='/townhall/']"}
 		,{"id":2021010435,"name":"Left Rail: Voting Information Center","selector":"[data-pagelet=page] [role=navigation] a[href*='/votinginformationcenter/']"}
 		,{"id":2021010436,"name":"Left Rail: Weather","selector":"[data-pagelet=page] [role=navigation] a[href*='/weather/']"}
-		,{"id":2021010501,"name":"Right Rail: Sponsored item","selector":"[data-pagelet=RightRail] .l9j0dhe7 > a.myohyog2"}
+		,{"id":2021010501,"name":"Right Rail: Sponsored item","selector":"[data-pagelet=RightRail] [role] .cbu4d94t .a8c37x1j>.gc8qjt7d","parent":".l9j0dhe7>.myohyog2"}
 		,{"id":2021010601,"name":"Left Rail: Crisis Response","selector":"[data-pagelet=page] [role=navigation] a[href*='/crisisresponse/']"}
 		,{"id":2021011001,"name":"Left Rail: Resources","selector":"[data-pagelet=page] [role=navigation] a[href*='/community_resources/']"}
 		,{"id":2021011002,"name":"Left Rail: Ad Center (Page admin)","selector":"[data-pagelet=page] [role=navigation] a[href*='/ad_center/']"}
 		,{"id":2021011003,"name":"Left Rail: Pages (Page admin)","selector":"[data-pagelet=page] [role=navigation] a[href*='/pages/?category=your_pages']"}
 		,{"id":2021011901,"name":"Groups Feed: Popular Now","selector":".aghb5jc5 .cbu4d94t a.btwxx1t3.g5ia77u1[href*='/topic/'] .fgxwclzu","parent":".aghb5jc5>div.lpgh02oy"}
-		,{"id":2021012401,"name":"Right Rail: Sponsored item (2)","selector":"[data-pagelet=RightRail] [role=button] .cbu4d94t .a8c37x1j>.gc8qjt7d","parent":".l9j0dhe7>.myohyog2"}
+		,{"id":2021012401,"name":"(removed)","selector":"xxyyzz"}
 		,{"id":2021012402,"name":"Header: 'Friends' button","selector":"[role=banner] [role=navigation] a[href*='/friends']"}
 	]
 }


### PR DESCRIPTION
2021010501 'Right Rail: Sponsored item' is updated to the prior contents of
2021012401 'Right Rail: Sponsored item (2)', except no '[role=button]'.

Turns out the 2nd form is how FB present ads to some people, then when the
ad is moused over, it morphs into the first form.  This means they can't
hide the 2nd form because while trying to hide it, it morphs into the 1st
form!  So, need a hider which encompasses both forms.

Unfortunately this makes the entire hider a 'parent' type hider, which is
slower, so now you see the ads briefly on every page load.