### PR TITLE
hideable.json: add 'Groups Feed: ad to join groups'

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -352,5 +352,6 @@
 		,{"id":2021011901,"name":"Groups Feed: Popular Now","selector":".aghb5jc5 .cbu4d94t a.btwxx1t3.g5ia77u1[href*='/topic/'] .fgxwclzu","parent":".aghb5jc5>div.lpgh02oy"}
 		,{"id":2021012401,"name":"(removed)","selector":"xxyyzz"}
 		,{"id":2021012402,"name":"Header: 'Friends' button","selector":"[role=banner] [role=navigation] a[href*='/friends']"}
+		,{"id":2021032201,"name":"Groups Feed: ad to join groups","selector":".aghb5jc5 .lpgh02oy .kb5gq1qc.t7l9tvuc .j83agx80 a.g5ia77u1[href*='groups/discover']","parent":".aghb5jc5>div.lpgh02oy"}
 	]
 }


### PR DESCRIPTION
The selector for this is particularly ugly, derived from a single
example (which I have a copy of) from Ieda.  As with all these
new-layout selectors, it's my guess of what unique page-construction
details lead down to this item; the only definitive bit is
a[href*='groups/discover'], but that could hit all sorts of other
things, so then I construct a path to the box out of whatever
weird things it has -- in this case including 'flex-grow:0' and
'.t7l9tvuc:last-of-type{margin-right:0}'.  Which makes it fragile to
future FB changes, but unlikely to hide things I don't intend...

![hide-friends-groups](https://user-images.githubusercontent.com/3022180/112067302-11959a80-8b25-11eb-906e-006d0b309440.jpeg)