### PR TITLE
hideable.json: add and update some top bar buttons

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -302,7 +302,7 @@
 		,{"id":2020120703,"name":"Header: 'Home' button","selector":"[role=banner] [role=navigation] a.bp9cbjyn[href='/']"}
 		,{"id":2020120704,"name":"Header: 'Gaming' button","selector":"[role=banner] [role=navigation] a[href*='/gaming/']"}
 		,{"id":2020120705,"name":"Header: 'More (Bookmarks)' button","selector":"[role=banner] [role=navigation] a[href*='/bookmarks/']"}
-		,{"id":2020120706,"name":"Header: 'My profile' button","selector":"[role=banner] [role=navigation] a[href='/me/']"}
+		,{"id":2020120706,"name":"Header: 'My profile' button","selector":"[role=banner] [role=navigation].rl25f0pe a[href*='/me/']","parent":"[role=banner] [role=navigation] > * > *"}
 		,{"id":2020121301,"name":"Group: About box","selector":".lntdvkbv .cwj9ozl2 .i1fnvgqd .o8rfisnq [class*='sp_'][class*='sx_'],.bexiecsf .cwj9ozl2 .i1fnvgqd .o8rfisnq [class*='sp_'][class*='sx_']","parent":".lntdvkbv,.bexiecsf"}
 		,{"id":2020121302,"name":"Group: Popular Topics box","selector":".lntdvkbv a[href*='/groups/'][href*='/post_tags/'],.lntdvkbv a[href*='/hashtag/'],.bexiecsf a[href*='/groups/'][href*='/post_tags/'],.bexiecsf a[href*='/hashtag/']","parent":".lntdvkbv,.bexiecsf"}
 		,{"id":2020121303,"name":"Group: Recent Media box","selector":".lntdvkbv a[href*='/groups/'][href*='/media/'],.bexiecsf a[href*='/groups/'][href*='/media/']","parent":".lntdvkbv,.bexiecsf"}
@@ -359,5 +359,10 @@
 		,{"id":2021041201,"name":"Left Rail: Footer","selector":"[data-pagelet=LeftRail] [role=contentinfo]"}
 		,{"id":2021041501,"name":"Right Rail: See All Contacts","selector":"[data-pagelet=RightRail] [role=button].taijpn5t.g5ia77u1.pq6dq46d"}
 		,{"id":2021042301,"name":"Post: Get Vaccine Info","selector":"[sfx_post] .hybvsw6c > a[href*='/coronavirus_info/']","parent":".discj3wi"}
+		,{"id":2021042901,"name":"Header: 'Notifications' menu","selector":"[role=banner] [role=navigation].rl25f0pe [href*='/notifications'],[role=banner] [role=navigation].rl25f0pe [aria-label*=Notifications]","parent":"[role=banner] [role=navigation] > * > *"}
+		,{"id":2021042902,"name":"Header: 'Create / Menu' menu","selector":"[role=banner] [role=navigation].rl25f0pe [aria-label*=Create]","parent":"[role=banner] [role=navigation] > * > *"}
+		,{"id":2021042903,"name":"Header: 'Messenger' menu","selector":"[role=banner] [role=navigation].rl25f0pe [aria-label*=Messenger]","parent":"[role=banner] [role=navigation] > * > *"}
+		,{"id":2021042904,"name":"Header: 'Account' button [DISABLED]","selector":"xxx [role=banner] [role=navigation].rl25f0pe [aria-label*=Account]","parent":"[role=banner] [role=navigation] > * > *"}
+		,{"id":2021042905,"name":"Header: 'Pages' button","selector":"[role=banner] [role=navigation].rl25f0pe a[href*=your_pages],[role=banner] [role=navigation].rl25f0pe [aria-label*=Pages]","parent":"[role=banner] [role=navigation] > * > *"}
 	]
 }

--- a/hideable.json
+++ b/hideable.json
@@ -285,10 +285,9 @@
 		,{"id":2020082301,"name":"Newsfeed: Stories (New Layout)","selector":"#ssrb_stories_start","parent":"div"}
 		,{"id":2020082302,"name":"Newsfeed: Rooms (New Layout)","selector":"div[data-pagelet^=VideoChatHomeUnit]","parent":"div"}
 		,{"id":2020082303,"name":"Right Column (New Layout)","selector":"div[data-pagelet=\"RightRail\"]"}
-		,{"id":2020082304,"name":"Header: Watch (New Layout)","selector":"div[role=\"banner\"] div[role=\"navigation\"] a[href=\"/watch/\"]"}
-		,{"id":2020082305,"name":"Header: Marketplace (New Layout)","selector":"div[role=\"banner\"] div[role=\"navigation\"] a[href^=\"/marketplace\"]"}
-		,{"id":2020082306,"name":"Header: Groups (New Layout)","selector":"div[role=\"banner\"] div[role=\"navigation\"] a[href^=\"/groups\"]"}
-
+		,{"id":2020082304,"name":"Header: Watch (New Layout)","selector":"[role=banner] [role=navigation] a[href*='/watch/']"}
+		,{"id":2020082305,"name":"Header: Marketplace (New Layout)","selector":"[role=banner] [role=navigation] a[href*='/marketplace']"}
+		,{"id":2020082306,"name":"Header: Groups (New Layout)","selector":"[role=banner] [role=navigation] a[href*='/groups']"}
 		,{"id":2020082501,"name":"Post: Post Insights / Post Boosting block","selector":"._5ybo._1q_o"}
 		,{"id":2020082502,"name":"Post: View Insights","selector":"a[type=button][href*='/post_insights/']"}
 		,{"id":2020082503,"name":"Post: People Reached","selector":"a[target=_blank][href*='/post_insights/']>div"}


### PR DESCRIPTION
- update 2020120706 'Header: 'My profile' button' to position hider correctly
- add 2021042901 'Header: 'Notifications' menu'
- add 2021042902 'Header: 'Create / Menu' menu'
- add 2021042903 'Header: 'Messenger' menu'
- add 2021042904 'Header: 'Pages' button'
- add 2021042905 'Header: 'Account' button [DISABLED]' (*)

(*) Support team agreed this was too dangerous to offer; this records
    its method, in case there's a future reason to offer it.

Some of these hiders use aria-label matching, which means they only
work when the FB user interface language is English.  For Create/Menu,
Messenger, and Account (DISABLED), I was unable to create a working
hider which didn't rely on aria-label.  For Pages and Notifications, I
supply aria-label as a 'backup' so the hider might continue to work
under some potential FB changes.  Also, only the aria-label
Notifications hider works on the persistent notifications page
(fb.com/notifications), as it doesn't provide a link to itself.

![hide-navbar-right-buttons](https://user-images.githubusercontent.com/3022180/116618553-0e47b880-a8f4-11eb-8615-289268543c96.png)

(no pic for Pages button, I don't admin any Pages and don't have the button; got HTML from a user)