### PR TITLE
hideable.json: update 2020082301 'News Feed: Stories' for variant layout

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -282,8 +282,8 @@
 		,{"id":356,"name":"Post Header: Founding Member Badge","selector":"a[href*='/groups/'][href*='FOUNDING_MEMBER']"}
 		,{"id":357,"name":"Left Col: Voting Information Center","selector":"#navItem_567708910575385"}
 
-		,{"id":2020082301,"name":"Newsfeed: Stories (New Layout)","selector":"#ssrb_stories_start","parent":"div"}
-		,{"id":2020082302,"name":"Newsfeed: Rooms (New Layout)","selector":"div[data-pagelet^=VideoChatHomeUnit]","parent":"div"}
+		,{"id":2020082301,"name":"News Feed: Stories","selector":"[data-pagelet=Stories]"}
+		,{"id":2020082302,"name":"News Feed: Rooms","selector":"div[data-pagelet^=VideoChatHomeUnit]","parent":"div"}
 		,{"id":2020082303,"name":"Right Column (New Layout)","selector":"div[data-pagelet=\"RightRail\"]"}
 		,{"id":2020082304,"name":"Header: 'Watch' button","selector":"[role=banner] [role=navigation] a[href*='/watch/']"}
 		,{"id":2020082305,"name":"Header: 'Marketplace' button","selector":"[role=banner] [role=navigation] a[href*='/marketplace']"}


### PR DESCRIPTION
Some users lack #ssrb_stories_start; all have [data-pagelet=Stories].

Also updated title (of this and 'Rooms') to match others -- don't need
to mention 'New Layout', and we use FB's 'News Feed' orthography, not
'Newsfeed'.