### PR TITLE
Games hiders, per fb.com/631732744899273

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -167,10 +167,10 @@
 		,{"id":241,"name":"Right Col: Recently Viewed on Marketplace","selector":"#pagelet_marketplace_recently_viewed_rhc"}
 		,{"id":242,"name":"Right Col: Still Available on Marketplace","selector":"#pagelet_marketplace_bsg_recently_viewed_rhc"}
 		,{"id":243,"name":"Right Col: Featured on Facebook Watch","selector":"#pagelet_video_home_promotion_rhc"}
-		,{"id":244,"name":"Right / Far Right Col: Instant Games","selector":"div[data-games-xout-query-type^='instant-games']"}
+		,{"id":244,"name":"retired","selector":"retired#retired"}
 		,{"id":245,"name":"retired","selector":"retired#retired"}
 		,{"id":246,"name":"Post: Recommend a place","selector":"[sfx_post] ._5ofu._1xap"}
-		,{"id":247,"name":"Right / Far Right Col: Your Games","selector":"div[data-games-xout-query-type='gyml-game-bookmarks']"}
+		,{"id":247,"name":"retired","selector":"retired#retired"}
 		,{"id":248,"name":"Group Right Col: Upcoming Group Events","selector":"._4-u3 a[href^='/groups/'][href$='/events/']","parent":"._4-u2"}
 		,{"id":249,"name":"Group Post Feed: Search For Items","selector":"a[target='_blank'][href^='/groups/'][href*='/for_sale_search/']","parent":"._4-u2"}
 		,{"id":250,"name":"Right Col: Unified Gaming Pagelet","selector":"#pagelet_games_unified_rhc"}
@@ -349,7 +349,7 @@
 		,{"id":2021011002,"name":"Left Rail: Ad Center (Page admin)","selector":"[data-pagelet=LeftRail] a[href*='/ad_center/']"}
 		,{"id":2021011003,"name":"Left Rail: Pages (Page admin)","selector":"[data-pagelet=LeftRail] a[href*='/pages/?category=your_pages']"}
 		,{"id":2021011901,"name":"Groups Feed Right Col: Popular Now","selector":".aghb5jc5 .cbu4d94t a.btwxx1t3.g5ia77u1[href*='/topic/'] .fgxwclzu","parent":".aghb5jc5>div.lpgh02oy"}
-		,{"id":2021012401,"name":"(removed)","selector":"xxyyzz"}
+		,{"id":2021012401,"name":"retired","selector":"retired#retired"}
 		,{"id":2021012402,"name":"Header: 'Friends' button","selector":"[role=banner] [role=navigation] a[href*='/friends']"}
 		,{"id":2021032201,"name":"Groups Feed Right Col: ad to join groups","selector":".g5gj957u.rek2kq2y [href*='groups/discover/']","parent":".aghb5jc5>div.lpgh02oy>.k4urcfbm"}
 		,{"id":2021041101,"name":"News Feed: Remember Password prompt","selector":"#ssrb_composer_start ~.ad2k81qe img[src*=switch]","parent":"#ssrb_composer_start ~.ad2k81qe"}
@@ -384,5 +384,15 @@
 		,{"id":2021072201,"name":"Left Rail: Olympics","selector":"[data-pagelet=LeftRail] a[href*=olympics_hub]"}
 		,{"id":2021082201,"name":"News Feed: Add a WhatsApp Button","selector":"#ssrb_composer_start ~.ad2k81qe a[href*='/settings/whatsapp']","parent":"#ssrb_composer_start ~.ad2k81qe"}
 		,{"id":2021091801,"name":"Post: Climate Science","selector":"[role=article] .hybvsw6c > a[href*='climatescience']","parent":".discj3wi"}
+		,{"id":2021092201,"name":"Games Right Col: Tournaments","selector":"#pagelet_canvas_nav_content ._gu1 a[href*=tournaments]","parent":"._gu1"}
+		,{"id":2021092202,"name":"Games Right Col: Featured Game (1)","selector":"#pagelet_canvas_nav_content ._gu1 a[href*='context_type=SOLO']","parent":"._gu1"}
+		,{"id":2021092203,"name":"Games Right Col: Featured Game (2)","selector":"#pagelet_canvas_nav_content ._2b2u a[data-gt*=games_featured]","parent":"._2b2u"}
+		,{"id":2021092204,"name":"Games Right Col: Top Games","selector":"#pagelet_canvas_nav_content ._gu1 a[data-gt*=LTVAppQuery]","parent":"._gu1"}
+		,{"id":2021092205,"name":"Games Right Col: Instant Games","selector":"#pagelet_canvas_nav_content ._gu1 a[data-gt*=GamesAppQuery]:not([data-gt*=LTVAppQuery])","parent":"._gu1"}
+		,{"id":2021092206,"name":"Games Right Col: Games Your Friends Play","selector":"#pagelet_canvas_nav_content ._gu1 a[data-gt*=InstantGamesYourFriends]","parent":"._gu1"}
+		,{"id":2021092207,"name":"Games Right Col: Game Category","selector":"#pagelet_canvas_nav_content ._gu1 a[data-gt*=InstantGamesAppCategories]","parent":"._gu1"}
+		,{"id":2021092208,"name":"Games Right Col: Your Games","selector":"#pagelet_canvas_nav_content ._gu1 a[data-gt*=GameBookmark]","parent":"._gu1"}
+		,{"id":2021092209,"name":"Games Right Col: Gaming Video","selector":"#games_video_canvas_rhc"}
 	]
 }
+/* 631732744899273 */


### PR DESCRIPTION
hideable.json: add 9 hiders for ads in the right column of games:

![hiders-games-025](https://user-images.githubusercontent.com/3022180/134326119-8db537d1-d586-44ad-824b-a5d5677f3bd9.png)

- 2021092201 'Games Right Col: Tournaments'
- 2021092202 'Games Right Col: Featured Game (1)'
- 2021092203 'Games Right Col: Featured Game (2)'
- 2021092204 'Games Right Col: Top Games'
- 2021092205 'Games Right Col: Instant Games'
- 2021092206 'Games Right Col: Games Your Friends Play'
- 2021092207 'Games Right Col: Game Category' (*)
- 2021092208 'Games Right Col: Your Games'
- 2021092209 'Games Right Col: Gaming Video'

(*) I assume this will cycle through different categories other than
'Puzzle Games', though that's all I've seen.  There's nothing to
distinguish the categories other than the title, which isn't really
accessible to a hider.

hideable.json: retire old versions of 2 of these (244 & 247)
hideable.json: use the same notation for all retired entries