### PR TITLE
Split 'Suggested' off from 'Sponsored' filter

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -109,7 +109,7 @@
 		"configurable_actions": true,
 		"title": "Hide Sponsored Posts",
 		"stop_on_match": true,
-		"description": "Hide Sponsored posts from the news feed"
+		"description": "Hide 'Sponsored' posts from the News Feed"
 	}, {
 		"id": 2021082601,
 		"match": "ALL",
@@ -117,16 +117,16 @@
 			"target": "any",
 			"operator": "startswith",
 			"condition": {
-				"text": ".{0,5}(Because you may be interested in|Because you recently viewed|You recently viewed a similar group|Post from a public group|From a group with members who like|From a group that|Suggested for you|Suggested Pages|(?:More Like|Suggested Groups).{1,120}posts? a (?:day|week|month))"
+				"text": ".{0,5}(Because you may be interested in|Because you recently viewed|You recently viewed a similar group|Post from a public group|From a group with members who like|From a group that|From a group you|Suggested for you|Suggested Pages|(?:More Like|Suggested Groups).{1,120}posts? a (?:day|week|month))"
 			}
 		}],
 		"actions": [{
 			"action": "hide",
 			"show_note": true,
-			"tab": "Suggested Posts",
-			"custom_note": "Suggested Post spam: ${1:50}"
+			"tab": "Suggested",
+			"custom_note": "Suggested: click to show/hide '${1:60}'"
 		}, {
-			"tab": "Suggested Posts"
+			"tab": "Suggested"
 		}],
 		"configurable_actions": true,
 		"title": "Hide Suggested Posts",
@@ -479,7 +479,7 @@
 			"replace": "IFL"
 		}],
 		"title": "I F'ing Love ...",
-		"description": "Replace any Page names like \"I F'ing Love Science\" with \"IFL\""
+		"description": "Replace any Page names like 'I F'ing Love Science' with 'IFL'"
 	}, {
 		"id": 8,
 		"match": "ALL",
@@ -499,7 +499,7 @@
 		}],
 		"configurable_actions": true,
 		"title": "Hide Spoilers",
-		"description": "If a post contains the word \"spoiler\" anywhere in it, hide it and display a message to click to show the post."
+		"description": "If a post contains the word 'spoiler' anywhere in it, hide it and display a message to click to show the post."
 	}, {
 		"id": 9,
 		"match": "ANY",
@@ -521,8 +521,8 @@
 			"show_note": true
 		}],
 		"configurable_actions": true,
-		"title": "Hide \"Shared Memories\"",
-		"description": "Hide re-posts of old memories in the news feed"
+		"title": "Hide 'Shared Memories'",
+		"description": "Hide re-posts of old memories in the News Feed"
 	}, {
 		"id": 10,
 		"match": "ANY",
@@ -544,8 +544,8 @@
 			"show_note": true
 		}],
 		"configurable_actions": true,
-		"title": "Hide \"People You May Know\"",
-		"description": "Filter the \"People You May Know\" story that appears in the News Feed occasionally."
+		"title": "Hide 'People You May Know'",
+		"description": "Filter the 'People You May Know' story that appears in the News Feed occasionally."
 	}, {
 		"id": 11,
 		"match": "ALL",
@@ -572,7 +572,7 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "a[href^=\"/saved/?cref\"]"
+				"text": "a[href^='/saved/?cref']"
 			}
 		}],
 		"actions": [{
@@ -580,7 +580,7 @@
 		}],
 		"configurable_actions": true,
 		"title": "Saved Posts Reminder",
-		"description": "Hide posts in the news feed that highlight things you've recently Saved to Facebook, which they are reminding you about."
+		"description": "Hide posts in the News Feed that highlight things you've recently Saved to Facebook, which they are reminding you about."
 	}, {
 		"id": 3,
 		"max_version": "0.0.0",

--- a/filters.json
+++ b/filters.json
@@ -2,7 +2,6 @@
 	"filters": [{
 		"id":20200713,
 		"match": "ANY",
-		"enabled": true,
 		"stop_on_match": true,
 		"rules": [
 			{
@@ -28,7 +27,6 @@
 	}, {
 		"id": 29,
 		"match": "ALL",
-		"enabled": false,
 		"max_version": "0.0.0",
 		"stop_on_match": true,
 		"rules": [{
@@ -109,9 +107,31 @@
 			"tab": "Sponsored"
 		}],
 		"configurable_actions": true,
-		"title": "Hide Sponsored and Suggested Posts",
+		"title": "Hide Sponsored Posts",
 		"stop_on_match": true,
-		"description": "Hide all Sponsored and Suggested posts from the news feed"
+		"description": "Hide Sponsored posts from the news feed"
+	}, {
+		"id": 2021082601,
+		"match": "ALL",
+		"rules": [{
+			"target": "any",
+			"operator": "startswith",
+			"condition": {
+				"text": ".{0,5}(Because you may be interested in|Because you recently viewed|You recently viewed a similar group|Post from a public group|From a group with members who like|From a group that|Suggested for you|(?:More Like|Suggested Groups).{1,120}posts? a (?:day|week|month))"
+			}
+		}],
+		"actions": [{
+			"action": "hide",
+			"show_note": true,
+			"tab": "Suggested Posts",
+			"custom_note": "Suggested Post spam: ${1:50}"
+		}, {
+			"tab": "Suggested Posts"
+		}],
+		"configurable_actions": true,
+		"title": "Hide Suggested Posts / Groups",
+		"stop_on_match": true,
+		"description": "Hide 'Suggested Posts' and similar things in Groups Feed (a few in News Feed).  NOTE: English-language FB only"
 	}, {
 		"id": 23,
 		"match": "ANY",
@@ -383,7 +403,6 @@
 			"custom_note": "Game of Thrones spoiler hidden"
 		}],
 		"configurable_actions": true,
-		"enabled": false,
 		"max_version": "0.0.0",
 		"title": "Hide Game of Thrones Spoilers til Monday",
 		"description": "Hide posts with any mention of Game of Thrones but only on Sunday night and show a spoiler warning note instead. Show them again on Monday."
@@ -403,7 +422,6 @@
 			"custom_note": "Game of Thrones post hidden"
 		}],
 		"configurable_actions": true,
-		"enabled": false,
 		"max_version": "0.0.0",
 		"title": "Hide all posts about Game of Thrones",
 		"description": "Hide posts with any mention of Game of Thrones."
@@ -565,7 +583,6 @@
 		"description": "Hide posts in the news feed that highlight things you've recently Saved to Facebook, which they are reminding you about."
 	}, {
 		"id": 3,
-		"enabled": false,
 		"max_version": "0.0.0",
 		"match": "ALL",
 		"rules": [{

--- a/filters.json
+++ b/filters.json
@@ -117,7 +117,7 @@
 			"target": "any",
 			"operator": "startswith",
 			"condition": {
-				"text": ".{0,5}(Because you may be interested in|Because you recently viewed|You recently viewed a similar group|Post from a public group|From a group with members who like|From a group that|Suggested for you|(?:More Like|Suggested Groups).{1,120}posts? a (?:day|week|month))"
+				"text": ".{0,5}(Because you may be interested in|Because you recently viewed|You recently viewed a similar group|Post from a public group|From a group with members who like|From a group that|Suggested for you|Suggested Pages|(?:More Like|Suggested Groups).{1,120}posts? a (?:day|week|month))"
 			}
 		}],
 		"actions": [{
@@ -129,9 +129,9 @@
 			"tab": "Suggested Posts"
 		}],
 		"configurable_actions": true,
-		"title": "Hide Suggested Posts / Groups",
+		"title": "Hide Suggested Posts",
 		"stop_on_match": true,
-		"description": "Hide 'Suggested Posts' and similar things in Groups Feed (a few in News Feed).  NOTE: English-language FB only"
+		"description": "Hide various sorts of 'Suggested' posts in News & Groups Feeds (NOTE: English-language FB only)"
 	}, {
 		"id": 23,
 		"match": "ANY",


### PR DESCRIPTION
The filter has been called 'Sponsored and Suggested' forever, but the word 'Suggested' came from early FB weasel words about ads, **not** their later propensity for adding all sorts of 'Suggested Posts', 'Suggested Groups', etc.  This has been an ongoing source of confusion and displeasure for users.

This now adds a 'Suggested' filter which covers all the sorts of suggested-post crud I am aware of at the moment.  Of course it will need to be updated frequently since they are ever creative in this regard.

(Testing it today on fb.com/groups, I saw at least one instance of a post from a group I am not associated with, posted by a person I am not associated with, with **no** 'Here is some crap we thought you'd like' action-string.  I don't see how we can filter those except by keeping a list of subscribed-groups like we do of friends, and matching group-posted-in against that list.  Which is doable, but not currently in sight.)

Plus minor consistency twiddles.