### PR TITLE
hideable.json: add 2021100601 'Left Rail: Memories (2)'

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -328,5 +328,6 @@
 		,{"id":2021100512,"name":"Right Rail: Recently Saved [alt]","selector":"#ssrb_rhc_start ~ div a[href*='/saved']","parent":"#ssrb_rhc_start ~ div > * > *"}
 		,{"id":2021100513,"name":"Right Rail: Watch [alt]","selector":"#ssrb_rhc_start ~ div a[href*='/watch']","parent":"#ssrb_rhc_start ~ div > * > *"}
 		,{"id":2021100514,"name":"News Feed: Rooms [alt]","selector":".io0zqebd.hybvsw6c [role=region] .qdtcsgvi > [aria-label]","parent":"#ssrb_composer_start ~ *"}
+		,{"id":2021100601,"name":"Left Rail: Memories (2)","selector":"[data-pagelet=LeftRail] a[href*='/onthisday/']"}
 	]
 }


### PR DESCRIPTION
Replacing 2021010423's payload didn't work, neither as comma-separated
old,new nor as just the new selector.  Don't understand why, but, this
means it'll continue to work for people with either code sent down by
FB, although they'll have to re-hide it when it transitions.