### PR TITLE
tweaks.json: update 2021093001 'Fix date-stamp blobs' to handle upper left corner blobs

### DIFF
--- a/tweaks.json
+++ b/tweaks.json
@@ -25,7 +25,7 @@
 			"id" : 2021093001,
 			"title": "Fix date-stamp blobs (TEMP FIX)",
 			"description": "This is a TEMPORARY fix until a future update of Social Fixer.\n\nRecent FB changes have caused Social Fixer to litter the News Feed with black (white in 'dark mode') date-stamp blobs.  Fixing this requires code changes.  For now, this tweak makes those blobs fade out after 5 seconds.\n\nWe know this is still irritating.  However, other parts of FB user interface use these blobs.  For instance, hovering who 'Liked' a post.  Making these blobs completely invisible would break parts of FB.",
-			"css": "/* Fix date-stamp blobs -- TEMP FIX -- v1.1 30Sep21\n\n   This actually works by fading out *all* hover blobs after\n   five seconds.  The blobs are still present but invisible. */\n\n[class*='-mode'] > .pmk7jnqg[style*=translate] > [role=tooltip] { animation:sfx_nostamp 100000s !important; }\n@keyframes sfx_nostamp {\n  from { opacity:1; }\n  0.0050% { opacity:1; }\n  0.0055% { opacity:0; }\n  to { opacity:0; }\n}"
+			"css": "/* Fix date-stamp blobs -- TEMP FIX -- v1.1 30Sep21\n\n   This actually works by fading out *all* hover blobs after\n   five seconds.  The blobs are still present but invisible. */\n\n[class*='-mode'] > .pmk7jnqg > [role=tooltip] { animation:sfx_nostamp 100000s !important; }\n@keyframes sfx_nostamp {\n  from { opacity:1; }\n  0.0050% { opacity:1; }\n  0.0055% { opacity:0; }\n  to { opacity:0; }\n}"
 		}, {
 			"id" : 2021100701,
 			"title": "Improved Hide/Show interface & tooltips",


### PR DESCRIPTION
This change makes it more likely that non-date-stamp blobs will be affected.  I haven't yet seen an example, though, and they will remain visible for 5s like the date-stamp blobs, so ... probably OK.

Many bug reports about these remaining blobs in the upper left corner of the page.