### PR TITLE
hideable.json: make Right Rail alt and not-alt entries mutually exclusive

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -316,16 +316,16 @@
 		,{"id":2021100501,"name":"Right Rail: Recently Saved","selector":"[data-pagelet=RightRail] a[href*='/saved']","parent":"[data-pagelet=RightRail] > * > *"}
 		,{"id":2021100502,"name":"Right Rail: Watch","selector":"[data-pagelet=RightRail] a[href*='/watch']","parent":"[data-pagelet=RightRail] > * > *"}
 		,{"id":2021100503,"name":"Give Award (Post Comment)","selector":"[role=article] li span[aria-hidden=true] ~ .gs1a9yip","parent":"li"}
-		,{"id":2021100504,"name":"Right Rail (entire block) [alt]","selector":"#ssrb_rhc_start ~ div"}
-		,{"id":2021100505,"name":"Right Rail: Sponsored [alt]","selector":"#ssrb_rhc_start ~ div .cbu4d94t .a8c37x1j>.gc8qjt7d","parent":"#ssrb_rhc_start ~ div > * > *"}
-		,{"id":2021100506,"name":"Right Rail: See All Contacts [alt]","selector":"#ssrb_rhc_start ~ div [role=button].taijpn5t.g5ia77u1.pq6dq46d"}
-		,{"id":2021100507,"name":"Right Rail: Birthdays [alt]","selector":"#ssrb_rhc_start ~ div [href*='/events/birthdays']","parent":"#ssrb_rhc_start ~ div > * > *"}
-		,{"id":2021100508,"name":"Right Rail: Friend Requests (list) [alt]","selector":"#ssrb_rhc_start ~ div [href*='/friends/'][href*=profile_id]"}
-		,{"id":2021100509,"name":"Right Rail: Friend Requests (entire block) [alt]","selector":"#ssrb_rhc_start ~ div [href*='/friends/'][href*=profile_id]","parent":"#ssrb_rhc_start ~ div > * > *"}
-		,{"id":2021100510,"name":"Right Rail: Play Games [alt]","selector":"#ssrb_rhc_start ~ div a[href*='games/'][href*=rhc_discovery]","parent":"#ssrb_rhc_start ~ div > * > *"}
-		,{"id":2021100511,"name":"Right Rail: Your Pages [alt]","selector":"#ssrb_rhc_start ~ div a[href*='ad_center/create'][href*=rhc_page]","parent":"#ssrb_rhc_start ~ div > * > *"}
-		,{"id":2021100512,"name":"Right Rail: Recently Saved [alt]","selector":"#ssrb_rhc_start ~ div a[href*='/saved']","parent":"#ssrb_rhc_start ~ div > * > *"}
-		,{"id":2021100513,"name":"Right Rail: Watch [alt]","selector":"#ssrb_rhc_start ~ div a[href*='/watch']","parent":"#ssrb_rhc_start ~ div > * > *"}
+		,{"id":2021100504,"name":"Right Rail (entire block) [alt]","selector":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail])"}
+		,{"id":2021100505,"name":"Right Rail: Sponsored [alt]","selector":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) .cbu4d94t .a8c37x1j>.gc8qjt7d","parent":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) > * > *"}
+		,{"id":2021100506,"name":"Right Rail: See All Contacts [alt]","selector":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) [role=button].taijpn5t.g5ia77u1.pq6dq46d"}
+		,{"id":2021100507,"name":"Right Rail: Birthdays [alt]","selector":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) [href*='/events/birthdays']","parent":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) > * > *"}
+		,{"id":2021100508,"name":"Right Rail: Friend Requests (list) [alt]","selector":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) [href*='/friends/'][href*=profile_id]"}
+		,{"id":2021100509,"name":"Right Rail: Friend Requests (entire block) [alt]","selector":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) [href*='/friends/'][href*=profile_id]","parent":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) > * > *"}
+		,{"id":2021100510,"name":"Right Rail: Play Games [alt]","selector":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) a[href*='games/'][href*=rhc_discovery]","parent":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) > * > *"}
+		,{"id":2021100511,"name":"Right Rail: Your Pages [alt]","selector":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) a[href*='ad_center/create'][href*=rhc_page]","parent":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) > * > *"}
+		,{"id":2021100512,"name":"Right Rail: Recently Saved [alt]","selector":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) a[href*='/saved']","parent":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) > * > *"}
+		,{"id":2021100513,"name":"Right Rail: Watch [alt]","selector":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) a[href*='/watch']","parent":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) > * > *"}
 		,{"id":2021100514,"name":"News Feed: Rooms [alt]","selector":".io0zqebd.hybvsw6c [role=region] .qdtcsgvi > [aria-label]","parent":"#ssrb_composer_start ~ *"}
 		,{"id":2021100601,"name":"Left Rail: Memories (2)","selector":"[data-pagelet=LeftRail] a[href*='/onthisday/']"}
 		,{"id":2021101401,"name":"Post Comment: Awards Given","selector":"[role=article] [role=article] .sf5mxxl7 .q3qqxkgz.mrjvor2e.b8zhkkm9","parent":"[role=button]"}


### PR DESCRIPTION
Some users get a Right Rail with [data-pagelet=RightRail]; others lack
that.  I don't know what else is different in the structures, but
empirically the two sets of hiders do work.  However, if a single user's
FB switches back and forth, sections can be hidden by one while the
other still matches and displays a hider *on top of* the unhider for the
other one; making it impossible to unhide.

With these mutually exclusive hiders, the user may need to re-hide
things they previously hid; may need to hide things twice, as FB flip
them back and forth between code sets.  But at least everything will
work rationally.

Both sets could be combined using CSS comma alternation (on both the
selector & parent selector).  But I did that before and had problems that
I can't remember the details of.  Leaving them separate for safety.