### PR TITLE
Make Left Rail items more universal, plus 3 new hiders

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -161,7 +161,7 @@
 		,{"id":307,"name":"Timeline Left Col: Life Events","selector":"#profile_timeline_tiles_unit_pagelets_life_events"}
 		,{"id":308,"name":"Marketplace: Sponsored","selector":"[data-testid^='marketplace'] ._6y8t[style]"}
 		,{"id":310,"name":"Post: Add this photo to your story?","selector":"[data-onclick*='add_to_story']","parent":"._1kyo"}
-		,{"id":311,"name":"Post: Ask Your Community for Support","selector":"[href*='/fundraiser/with_presence/create_dialog/']","parent":"._1s31"}
+		,{"id":311,"name":"Post: Ask Your Community for Support","selector":"[href*='/fundraiser/with_presence/create_dialog']","parent":"._1s31"}
 		,{"id":312,"name":"Nub: Keyboard Shortcut Help","selector":"a.fbNubButton[aria-label='Keyboard Shortcut Help']"}
 		,{"id":313,"name":"Right Col: Happening Now","selector":"#pagelet_live_destination_rhc"}
 		,{"id":314,"name":"Right Col: Videos From Facebook Watch","selector":"#pagelet_video_home_rhc"}
@@ -226,55 +226,55 @@
 		,{"id":2020121303,"name":"Group Right Col: Recent Media","selector":".lntdvkbv a[href*='/groups/'][href*='/media/'],.bexiecsf a[href*='/groups/'][href*='/media/'],[data-pagelet=DiscussionRootSuccess] .lntdvkbv a[href*='/photo/'],[data-pagelet=DiscussionRootSuccess] .bexiecsf a[href*='/photo/'],[data-pagelet=DiscussionRootSuccess] .lntdvkbv a[href*='/video/'],[data-pagelet=DiscussionRootSuccess] .bexiecsf a[href*='/video/']","parent":".lntdvkbv,.bexiecsf"}
 		,{"id":2020121304,"name":"Group Right Col: Events","selector":".lntdvkbv a[href*='/events/'],.bexiecsf a[href*='/events/']","parent":".lntdvkbv,.bexiecsf"}
 		,{"id":2020123101,"name":"Friends page: People You May Know","selector":"html[sfx_url='/friends'] .btwxx1t3.gs1a9yip > .cbu4d94t[role=navigation]"}
-		,{"id":2021010401,"name":"Left Rail: Friends","selector":"[data-pagelet=LeftRail] a[href*='/friends/']"}
-		,{"id":2021010402,"name":"Left Rail: Groups","selector":"[data-pagelet=LeftRail] a[href*='/groups/'][href*='ref=bookmarks']"}
-		,{"id":2021010403,"name":"Left Rail: Marketplace","selector":"[data-pagelet=LeftRail] a[href*='/marketplace/']"}
-		,{"id":2021010404,"name":"Left Rail: Watch","selector":"[data-pagelet=LeftRail] a[href*='/watch/']:not([href*='/live/'])"}
-		,{"id":2021010405,"name":"Left Rail: Ad Center","selector":"[data-pagelet=LeftRail] a[href*='/pages/creation/']"}
-		,{"id":2021010406,"name":"Left Rail: Ads Manager","selector":"[data-pagelet=LeftRail] a[href*='/ad_campaign/']"}
-		,{"id":2021010407,"name":"Left Rail: Blood Donations","selector":"[data-pagelet=LeftRail] a[href*='/blooddonations/']"}
-		,{"id":2021010408,"name":"Left Rail: Buy and Sell Groups","selector":"[data-pagelet=LeftRail] a[href*='/salegroups/']"}
-		,{"id":2021010409,"name":"Left Rail: Campus","selector":"[data-pagelet=LeftRail] a[href*='/campus/']"}
-		,{"id":2021010410,"name":"Left Rail: Climate Science Center","selector":"[data-pagelet=LeftRail] a[href*='/climatescienceinfo/']"}
-		,{"id":2021010411,"name":"Left Rail: Community Help","selector":"[data-pagelet=LeftRail] a[href*='/community_help/']"}
-		,{"id":2021010412,"name":"Left Rail: COVID-19 Information Center","selector":"[data-pagelet=LeftRail] a[href*='/coronavirus_info/']"}
-		,{"id":2021010413,"name":"Left Rail: Events","selector":"[data-pagelet=LeftRail] a[href*='/events?']"}
-		,{"id":2021010414,"name":"Left Rail: Facebook Pay","selector":"[data-pagelet=LeftRail] a[href*='/facebook_pay/']"}
-		,{"id":2021010415,"name":"Left Rail: Favorites","selector":"[data-pagelet=LeftRail] a[href*='/?sk=favorites']"}
-		,{"id":2021010416,"name":"Left Rail: Friend Lists","selector":"[data-pagelet=LeftRail] a[href*='/bookmarks/lists/']"}
-		,{"id":2021010417,"name":"Left Rail: Fundraisers","selector":"[data-pagelet=LeftRail] a[href*='/fundraisers/']"}
-		,{"id":2021010418,"name":"Left Rail: Play Games","selector":"[data-pagelet=LeftRail] a[href*='/gaming/play/']"}
-		,{"id":2021010419,"name":"Left Rail: Gaming Video","selector":"[data-pagelet=LeftRail] a[href*='/gaming/'][href*=video]"}
-		,{"id":2021010420,"name":"Left Rail: Jobs","selector":"[data-pagelet=LeftRail] a[href*='/jobs/']"}
-		,{"id":2021010421,"name":"Left Rail: Lift Black Voices","selector":"[data-pagelet=LeftRail] a[href*='/liftblackvoices/']"}
-		,{"id":2021010422,"name":"Left Rail: Live Videos","selector":"[data-pagelet=LeftRail] a[href*='/watch/live/']"}
-		,{"id":2021010423,"name":"Left Rail: Memories","selector":"[data-pagelet=LeftRail] a[href*='/memories/']"}
-		,{"id":2021010424,"name":"Left Rail: Messenger","selector":"[data-pagelet=LeftRail] a[href$='/messages/t/']"}
-		,{"id":2021010425,"name":"Left Rail: Messenger Kids","selector":"[data-pagelet=LeftRail] a[href*='/messenger_kids/']"}
-		,{"id":2021010426,"name":"Left Rail: Most Recent","selector":"[data-pagelet=LeftRail] a[href*='/?sk=h_chr']"}
-		,{"id":2021010427,"name":"Left Rail: Movies","selector":"[data-pagelet=LeftRail] a[href*='/movies/']"}
-		,{"id":2021010428,"name":"Left Rail: Oculus","selector":"[data-pagelet=LeftRail] a[href*='/270208243080697/']"}
-		,{"id":2021010429,"name":"Left Rail: Offers","selector":"[data-pagelet=LeftRail] a[href*='/offers/']"}
-		,{"id":2021010430,"name":"Left Rail: Pages","selector":"[data-pagelet=LeftRail] a[href*='/pages/?category=top']"}
-		,{"id":2021010431,"name":"Left Rail: Recent Ad Activity","selector":"[data-pagelet=LeftRail] a[href*='/ads/activity/']"}
-		,{"id":2021010432,"name":"Left Rail: Recommendations","selector":"[data-pagelet=LeftRail] a[href*='/recommendations']"}
-		,{"id":2021010433,"name":"Left Rail: Saved","selector":"[data-pagelet=LeftRail] a[href*='/saved/']"}
-		,{"id":2021010434,"name":"Left Rail: Town Hall","selector":"[data-pagelet=LeftRail] a[href*='/townhall/']"}
-		,{"id":2021010435,"name":"Left Rail: Voting Information Center","selector":"[data-pagelet=LeftRail] a[href*='/votinginformationcenter/']"}
-		,{"id":2021010436,"name":"Left Rail: Weather","selector":"[data-pagelet=LeftRail] a[href*='/weather/']"}
+		,{"id":2021010401,"name":"Left Rail: Friends","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/friends/']"}
+		,{"id":2021010402,"name":"Left Rail: Groups","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/groups/'][href*='ref=bookmarks']"}
+		,{"id":2021010403,"name":"Left Rail: Marketplace","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/marketplace/']"}
+		,{"id":2021010404,"name":"Left Rail: Watch","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/watch/']:not([href*='/live/'])"}
+		,{"id":2021010405,"name":"Left Rail: Ad Center","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/pages/creation/']"}
+		,{"id":2021010406,"name":"Left Rail: Ads Manager","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/ad_campaign/']"}
+		,{"id":2021010407,"name":"Left Rail: Blood Donations","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/blooddonations/']"}
+		,{"id":2021010408,"name":"Left Rail: Buy and Sell Groups","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/salegroups/']"}
+		,{"id":2021010409,"name":"Left Rail: Campus","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/campus/']"}
+		,{"id":2021010410,"name":"Left Rail: Climate Science Center","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/climatescienceinfo/']"}
+		,{"id":2021010411,"name":"Left Rail: Community Help","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/community_help/']"}
+		,{"id":2021010412,"name":"Left Rail: COVID-19 Information Center","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/coronavirus_info/']"}
+		,{"id":2021010413,"name":"Left Rail: Events","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/events?']"}
+		,{"id":2021010414,"name":"Left Rail: Facebook Pay","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/facebook_pay/']"}
+		,{"id":2021010415,"name":"Left Rail: Favorites","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/?sk=favorites']"}
+		,{"id":2021010416,"name":"Left Rail: Friend Lists","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/bookmarks/lists/']"}
+		,{"id":2021010417,"name":"Left Rail: Fundraisers","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/fundraisers/']"}
+		,{"id":2021010418,"name":"Left Rail: Play Games","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/gaming/play/']"}
+		,{"id":2021010419,"name":"Left Rail: Gaming Video","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/gaming/'][href*=video]"}
+		,{"id":2021010420,"name":"Left Rail: Jobs","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/jobs/']"}
+		,{"id":2021010421,"name":"Left Rail: Lift Black Voices","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/liftblackvoices/']"}
+		,{"id":2021010422,"name":"Left Rail: Live Videos","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/watch/live/']"}
+		,{"id":2021010423,"name":"Left Rail: Memories","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/memories/']"}
+		,{"id":2021010424,"name":"Left Rail: Messenger","selector":"#ssrb_left_rail_start~[role] h2~div a[href$='/messages/t/']"}
+		,{"id":2021010425,"name":"Left Rail: Messenger Kids","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/messenger_kids/']"}
+		,{"id":2021010426,"name":"Left Rail: Most Recent","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/?sk=h_chr']"}
+		,{"id":2021010427,"name":"Left Rail: Movies","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/movies/']"}
+		,{"id":2021010428,"name":"Left Rail: Oculus","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/270208243080697/']"}
+		,{"id":2021010429,"name":"Left Rail: Offers","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/offers/']"}
+		,{"id":2021010430,"name":"Left Rail: Pages","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/pages/?category=top']"}
+		,{"id":2021010431,"name":"Left Rail: Recent Ad Activity","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/ads/activity/']"}
+		,{"id":2021010432,"name":"Left Rail: Recommendations","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/recommendations']"}
+		,{"id":2021010433,"name":"Left Rail: Saved","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/saved/']"}
+		,{"id":2021010434,"name":"Left Rail: Town Hall","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/townhall/']"}
+		,{"id":2021010435,"name":"Left Rail: Voting Information Center","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/votinginformationcenter/']"}
+		,{"id":2021010436,"name":"Left Rail: Weather","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/weather/']"}
 		,{"id":2021010501,"name":"Right Rail: Sponsored","selector":"[data-pagelet=RightRail] .cbu4d94t .a8c37x1j>.gc8qjt7d","parent":"[data-pagelet=RightRail] > * > *"}
-		,{"id":2021010601,"name":"Left Rail: Crisis Response","selector":"[data-pagelet=LeftRail] a[href*='/crisisresponse/']"}
-		,{"id":2021011001,"name":"Left Rail: Resources","selector":"[data-pagelet=LeftRail] a[href*='/community_resources/']"}
-		,{"id":2021011002,"name":"Left Rail: Ad Center (Page admin)","selector":"[data-pagelet=LeftRail] a[href*='/ad_center/']"}
-		,{"id":2021011003,"name":"Left Rail: Pages (Page admin)","selector":"[data-pagelet=LeftRail] a[href*='/pages/?category=your_pages']"}
+		,{"id":2021010601,"name":"Left Rail: Crisis Response","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/crisisresponse/']"}
+		,{"id":2021011001,"name":"Left Rail: Resources","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/community_resources/']"}
+		,{"id":2021011002,"name":"Left Rail: Ad Center (Page admin)","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/ad_center/']"}
+		,{"id":2021011003,"name":"Left Rail: Pages (Page admin)","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/pages/?category=your_pages']"}
 		,{"id":2021011901,"name":"Groups Feed Right Col: Popular Now","selector":".aghb5jc5 .cbu4d94t a.btwxx1t3.g5ia77u1[href*='/topic/'] .fgxwclzu","parent":".aghb5jc5>div.lpgh02oy"}
 		,{"id":2021012401,"name":"retired","selector":"retired#retired"}
 		,{"id":2021012402,"name":"Header: 'Friends' button","selector":"[role=banner] [role=navigation] a[href*='/friends']"}
 		,{"id":2021032201,"name":"Groups Feed Right Col: ad to join groups","selector":".g5gj957u.rek2kq2y [href*='groups/discover/']","parent":".aghb5jc5>div.lpgh02oy>.k4urcfbm"}
 		,{"id":2021041101,"name":"News Feed: Remember Password prompt","selector":"#ssrb_composer_start ~.ad2k81qe img[src*=switch]","parent":"#ssrb_composer_start ~ *"}
 		,{"id":2021041102,"name":"News Feed: Take A Survey prompt","selector":"#ssrb_composer_start ~.ad2k81qe a[href*='/survey/']","parent":"#ssrb_composer_start ~ *"}
-		,{"id":2021041103,"name":"Left Rail: News","selector":"[data-pagelet=LeftRail] a[href*='/news/']"}
-		,{"id":2021041201,"name":"Left Rail: Footer","selector":"[data-pagelet=LeftRail] [role=contentinfo]"}
+		,{"id":2021041103,"name":"Left Rail: News","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/news/']"}
+		,{"id":2021041201,"name":"Left Rail: Footer","selector":"#ssrb_left_rail_start~[role] h2~div [role=contentinfo]"}
 		,{"id":2021041501,"name":"Right Rail: See All Contacts","selector":"[data-pagelet=RightRail] [role=button].taijpn5t.g5ia77u1.pq6dq46d"}
 		,{"id":2021042301,"name":"Post: Covid Info","selector":"[role=article] .hybvsw6c > a[href*='coronavirus']","parent":".discj3wi"}
 		,{"id":2021042901,"name":"Header: 'Notifications' menu","selector":"[role=banner] [role=navigation].rl25f0pe [href*='/notifications'],[role=banner] [role=navigation].rl25f0pe [aria-label*=Notifications]","parent":"[role=banner] [role=navigation] > * > *"}
@@ -284,7 +284,7 @@
 		,{"id":2021042905,"name":"Header: 'Pages' button","selector":"[role=banner] [role=navigation] a[href*=your_pages]"}
 		,{"id":2021042906,"name":"Header: 'Menu' menu","selector":"[role=banner] [role=navigation].rl25f0pe [aria-label*=Menu]","parent":"[role=banner] [role=navigation] > * > *"}
 		,{"id":2021050101,"name":"Header: 'News' button","selector":"[role=banner] [role=navigation] a[href*='/news/']"}
-		,{"id":2021051301,"name":"Left Rail: Emotional Health","selector":"[data-pagelet=LeftRail] a[href*='/emotional_health/']"}
+		,{"id":2021051301,"name":"Left Rail: Emotional Health","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/emotional_health/']"}
 		,{"id":2021051501,"name":"Right Rail: Birthdays","selector":"[data-pagelet=RightRail] [href*='/events/birthdays']","parent":"[data-pagelet=RightRail] > * > *"}
 		,{"id":2021051502,"name":"Right Rail: Friend Requests (list)","selector":"[data-pagelet=RightRail] [href*='/friends/'][href*=profile_id]"}
 		,{"id":2021051503,"name":"Right Rail: Friend Requests (entire block)","selector":"[data-pagelet=RightRail] [href*='/friends/'][href*=profile_id]","parent":"[data-pagelet=RightRail] > * > *"}
@@ -298,9 +298,9 @@
 		,{"id":2021061601,"name":"Right Rail: Play Games","selector":"[data-pagelet=RightRail] a[href*='games/'][href*=rhc_discovery]","parent":"[data-pagelet=RightRail] > * > *"}
 		,{"id":2021061602,"name":"Right Rail: Your Pages","selector":"[data-pagelet=RightRail] a[href*='ad_center/create'][href*=rhc_page]","parent":"[data-pagelet=RightRail] > * > *"}
 		,{"id":2021062501,"name":"News Feed: Home-Favorites-Recent bar","selector":"[role=main] > .pfnyh3mw.cbu4d94t > .lpgh02oy.rek2kq2y > *"}
-		,{"id":2021071101,"name":"Post: FB pay-for-exposure ad","selector":".j1vyfwqu.l9j0dhe7 a[href*='/community_help/?page_source=gather_upsell']","parent":".j1vyfwqu.l9j0dhe7"}
-		,{"id":2021071801,"name":"Left Rail: Create Ad","selector":"[data-pagelet=LeftRail] a[href*='/ads/create_ad']"}
-		,{"id":2021072201,"name":"Left Rail: Olympics","selector":"[data-pagelet=LeftRail] a[href*=olympics_hub]"}
+		,{"id":2021071101,"name":"Post: FB pay-for-exposure ad","selector":"[role=article] .j1vyfwqu.l9j0dhe7 [href*='/community_help/?page_source=gather_upsell']","parent":".j1vyfwqu.l9j0dhe7"}
+		,{"id":2021071801,"name":"Left Rail: Create Ad","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/ads/create_ad']"}
+		,{"id":2021072201,"name":"Left Rail: Olympics","selector":"#ssrb_left_rail_start~[role] h2~div a[href*=olympics_hub]"}
 		,{"id":2021082201,"name":"News Feed: Add a WhatsApp Button","selector":"#ssrb_composer_start ~.ad2k81qe a[href*='/settings/whatsapp']","parent":"#ssrb_composer_start ~ *"}
 		,{"id":2021091801,"name":"Post: Climate Science","selector":"[role=article] .hybvsw6c > a[href*='climatescience']","parent":".discj3wi"}
 		,{"id":2021092201,"name":"Games Right Col: Tournaments","selector":"#pagelet_canvas_nav_content ._gu1 a[href*=tournaments]","parent":"._gu1"}
@@ -327,12 +327,15 @@
 		,{"id":2021100512,"name":"Right Rail: Recently Saved [alt]","selector":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) a[href*='/saved']","parent":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) > * > *"}
 		,{"id":2021100513,"name":"Right Rail: Watch [alt]","selector":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) a[href*='/watch']","parent":"#ssrb_rhc_start ~ div:not([data-pagelet=RightRail]) > * > *"}
 		,{"id":2021100514,"name":"News Feed: Rooms [alt]","selector":".io0zqebd.hybvsw6c [role=region] .qdtcsgvi > [aria-label]","parent":"#ssrb_composer_start ~ *"}
-		,{"id":2021100601,"name":"Left Rail: Memories (2)","selector":"[data-pagelet=LeftRail] a[href*='/onthisday/']"}
+		,{"id":2021100601,"name":"Left Rail: Memories (2)","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='/onthisday/']"}
 		,{"id":2021101401,"name":"Post Comment: Awards Given","selector":"[role=article] [role=article] .sf5mxxl7 .q3qqxkgz.mrjvor2e.b8zhkkm9","parent":"[role=button]"}
 		,{"id":2021101501,"name":"News Feed: Finish Donation","selector":"#ssrb_composer_start ~.ad2k81qe a[href*=donation_reminder]","parent":"#ssrb_composer_start ~ * > *"}
 		,{"id":2021101502,"name":"Post: Recommend a thing","selector":"[role=article] [role=article] .c1et5uql [role=link].rj84mg9z > .s1tcr66n","parent":".c1et5uql"}
 		,{"id":2021103101,"name":"Post: see groups like ...","selector":"[role=article] .s1tcr66n.bp9cbjyn a[href*='/discover/'][href*=group_trend]","parent":".s1tcr66n.bp9cbjyn"}
 		,{"id":2020103102,"name":"Profile: Add to Story","selector":"[href*='stories/create']","parent":"[data-pagelet] .g5gj957u > .k4urcfbm"}
 		,{"id":2020110101,"name":"News Feed: Create Story","selector":"[href*='stories/create'].gs1a9yip","parent":"[data-pagelet]"}
+		,{"id":2021111601,"name":"Left Rail: Oculus (2)","selector":"#ssrb_left_rail_start~[role] h2~div a[href*='oculus.com']"}
+		,{"id":2021111701,"name":"Post: Ask Your Community for Support","selector":"[role=article] .j1vyfwqu.l9j0dhe7 [href*='/fundraiser/with_presence/create_dialog']","parent":".j1vyfwqu.l9j0dhe7"}
+		,{"id":2021111702,"name":"Group Feed: See the latest coronavirus info","selector":"[data-pagelet=GroupFeed] .i1fnvgqd [href*=coronavirus_info]","parent":"[data-pagelet] > *"}
 	]
 }


### PR DESCRIPTION
hideable.json: add 2021111601 'Left Rail: Oculus (2)', alternate to 2021010428
hideable.json: add 2021111701 'Post: Ask Your Community for Support' (fb.com/655108652561682)
hideable.json: add 2021111702 'Group Feed: See the latest coronavirus info'
hideable.json: adjust a couple old entries for consistency
hideable.json: for Left Rail, use '#ssrb_left_rail_start' vs '[role=LeftRail]' (fb.com/669015097837704)

Most users get a Left Rail with '[data-pagelet=LeftRail]'; others
lack that.  '#ssrb_left_rail_start' seems to be universal.

![hide-group-feed-corona](https://user-images.githubusercontent.com/3022180/142367456-3f6cbdcd-78f2-4eb7-bea8-6c9d96d1e290.png)

no pics for others