### PR TITLE
news.json: fix 'Giviting Tuesday' spelling :)

### DIFF
--- a/news.json
+++ b/news.json
@@ -2,6 +2,6 @@
 	"news": [{
 		"time": 1638302651613,
 		"href": "https://www.facebook.com/socialfixer/posts/10159411290189342",
-		"title": "Giviting Tuesday - Donate to support Social Fixer!"
+		"title": "Giving Tuesday - Donate to support Social Fixer!"
 	}]
 }


### PR DESCRIPTION
I'm not immediately merging this, on the change that Matt might have done this on purpose for a sort of 'Streisand' effect.  Will try to reach him.