### PR TITLE
Once again update & repair Group Right Col items...

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -221,10 +221,10 @@
 		,{"id":2020120704,"name":"Header: 'Gaming' button","selector":"[role=banner] [role=navigation] a[href*='/gaming/']"}
 		,{"id":2020120705,"name":"Header: 'More (Bookmarks)' button","selector":"[role=banner] [role=navigation] a[href*='/bookmarks/']"}
 		,{"id":2020120706,"name":"Header: 'My profile' button","selector":"[role=banner] [role=navigation].rl25f0pe a[href*='/me/']","parent":"[role=banner] [role=navigation] > * > *"}
-		,{"id":2020121301,"name":"Group Right Col: About","selector":".rek2kq2y.l9j0dhe7.aghb5jc5 .lntdvkbv .cwj9ozl2 .i1fnvgqd .o8rfisnq.cbu4d94t,.rek2kq2y.l9j0dhe7 .bexiecsf .cwj9ozl2 .i1fnvgqd .o8rfisnq.cbu4d94t","parent":".lntdvkbv,.bexiecsf"}
-		,{"id":2020121302,"name":"Group Right Col: Popular Topics","selector":".lntdvkbv a[href*='/groups/'][href*='/post_tags/'],.lntdvkbv a[href*='/hashtag/'],.bexiecsf a[href*='/groups/'][href*='/post_tags/'],.bexiecsf a[href*='/hashtag/']","parent":".lntdvkbv,.bexiecsf"}
-		,{"id":2020121303,"name":"Group Right Col: Recent Media","selector":".lntdvkbv a[href*='/groups/'][href*='/media/'],.bexiecsf a[href*='/groups/'][href*='/media/'],[data-pagelet=DiscussionRootSuccess] .lntdvkbv a[href*='/photo/'],[data-pagelet=DiscussionRootSuccess] .bexiecsf a[href*='/photo/'],[data-pagelet=DiscussionRootSuccess] .lntdvkbv a[href*='/video/'],[data-pagelet=DiscussionRootSuccess] .bexiecsf a[href*='/video/']","parent":".lntdvkbv,.bexiecsf"}
-		,{"id":2020121304,"name":"Group Right Col: Events","selector":".lntdvkbv a[href*='/events/'],.bexiecsf a[href*='/events/']","parent":".lntdvkbv,.bexiecsf"}
+		,{"id":2020121301,"name":"Group: About","selector":".rek2kq2y.l9j0dhe7.aghb5jc5 .cwj9ozl2 .i1fnvgqd .o8rfisnq.cbu4d94t","parent":".j83agx80.l9j0dhe7.k4urcfbm"}
+		,{"id":2020121302,"name":"Group: Popular Topics","selector":".rek2kq2y.l9j0dhe7.aghb5jc5 a[href*='/groups/'][href*='/post_tags/'],.rek2kq2y.l9j0dhe7.aghb5jc5 a[href*='/hashtag/']","parent":".j83agx80.l9j0dhe7.k4urcfbm"}
+		,{"id":2020121303,"name":"Group: Recent Media","selector":".rek2kq2y.l9j0dhe7.aghb5jc5 .cwj9ozl2 .i1fnvgqd a[href*='/photo/'],.rek2kq2y.l9j0dhe7.aghb5jc5 .cwj9ozl2 .i1fnvgqd a[href*='/video/']","parent":".j83agx80.l9j0dhe7.k4urcfbm"}
+		,{"id":2020121304,"name":"Group: Events","selector":".rek2kq2y.l9j0dhe7.aghb5jc5 a[href*='/events/']","parent":".j83agx80.l9j0dhe7.k4urcfbm"}
 		,{"id":2020123101,"name":"Friends page: People You May Know","selector":"html[sfx_url='/friends'] .btwxx1t3.gs1a9yip > .cbu4d94t[role=navigation]"}
 		,{"id":2021010401,"name":"Left Rail: Friends","selector":"[role=navigation].rek2kq2y a[href*='/friends/']"}
 		,{"id":2021010402,"name":"Left Rail: Groups","selector":"[role=navigation].rek2kq2y a[href*='/groups/'][href*='ref=bookmarks']"}
@@ -292,8 +292,8 @@
 		,{"id":2021052902,"name":"Group Admin: 'Pending Posts' header","selector":"html[sfx_url*='/pending_posts'] [role=main] .d8ncny3e.d2edcug0 .du4w35lb.lpgh02oy .hybvsw6c > .rq0escxv:nth-of-type(1) > div","parent":".hybvsw6c > .rq0escxv"}
 		,{"id":2021052903,"name":"Group Admin: Pending Posts search-by-name box","selector":"html[sfx_url*='/pending_posts'] [role=main] .d8ncny3e.d2edcug0 .du4w35lb.lpgh02oy .hybvsw6c > .rq0escxv:nth-of-type(2) > div","parent":".hybvsw6c > .rq0escxv"}
 		,{"id":2021052904,"name":"Group Admin: Pending Posts bulk approve / decline","selector":"html[sfx_url*='/pending_posts'] [role=main] .d8ncny3e.d2edcug0 .du4w35lb.lpgh02oy .hybvsw6c > .rq0escxv:nth-of-type(3) > div","parent":".hybvsw6c > .rq0escxv"}
-		,{"id":2021060601,"name":"Group Right Col: Recent Files","selector":".lntdvkbv a[href*='/groups/'][href*='/files/'],.bexiecsf a[href*='/groups/'][href*='/files/']","parent":".lntdvkbv,.bexiecsf"}
-		,{"id":2021060602,"name":"Group Right Col: Rooms","selector":".lntdvkbv .bp9cbjyn.taijpn5t.cbu4d94t .oqcyycmt.m9osqain,.bexiecsf .bp9cbjyn.taijpn5t.cbu4d94t .oqcyycmt.m9osqain","parent":".lntdvkbv,.bexiecsf"}
+		,{"id":2021060601,"name":"Group: Recent Files","selector":".rek2kq2y.l9j0dhe7.aghb5jc5 a[href*='/files/']","parent":".j83agx80.l9j0dhe7.k4urcfbm"}
+		,{"id":2021060602,"name":"Group: Rooms","selector":".rek2kq2y.l9j0dhe7.aghb5jc5 .bp9cbjyn.taijpn5t.cbu4d94t .oqcyycmt.m9osqain","parent":".j83agx80.l9j0dhe7.k4urcfbm"}
 		,{"id":2021060901,"name":"Header: 'Events' button","selector":"[role=banner] [role=navigation] a[href*='/events/']"}
 		,{"id":2021061601,"name":"Right Rail: Play Games","selector":".msh19ytf.owycx6da [role=complementary] .ofs802cu > .buofh1pr > div a[href*='/gam'][href*=rhc_discovery]","parent":"[role=complementary] .ofs802cu > .buofh1pr > div > * > *"}
 		,{"id":2021061602,"name":"Right Rail: Your Pages","selector":".msh19ytf.owycx6da [role=complementary] .ofs802cu > .buofh1pr > div a[href*='ad_center/create'][href*=rhc_page]","parent":"[role=complementary] .ofs802cu > .buofh1pr > div > * > *"}
@@ -346,7 +346,7 @@
 		,{"id":2021121701,"name":"Post: Subscribe Now","selector":"[role=article] a[aria-label][href*='/support'][href*=entrypoint]","parent":"a[aria-label].pq6dq46d"}
 		,{"id":2022010501,"name":"Post: Let more people see","selector":"[role=article] .discj3wi.j1vyfwqu.l9j0dhe7 [aria-label*='Let more people see']","parent":".discj3wi.j1vyfwqu.l9j0dhe7"}
 		,{"id":2022010601,"name":"Post: Create subgroup","selector":"[role=article] .j83agx80.bp9cbjyn.i1fnvgqd.s1tcr66n a[href*=subfeed_recommendation]","parent":".j83agx80.bp9cbjyn.i1fnvgqd.s1tcr66n"}
-		,{"id":2022020701,"name":"Group Right Col: Create subgroup","selector":".rek2kq2y.l9j0dhe7.aghb5jc5 .oygrvhab.ii04i59q ~ div .gs1a9yip.i1fnvgqd.owycx6da","parent":".lpgh02oy > *"}
+		,{"id":2022020701,"name":"Group: Create subgroup","selector":".rek2kq2y.l9j0dhe7.aghb5jc5 .oygrvhab.ii04i59q ~ div .gs1a9yip.i1fnvgqd.owycx6da","parent":".j83agx80.l9j0dhe7.k4urcfbm"}
 		,{"id":2022021501,"name":"Favorites: A New Way ... [DISABLED]","selector":"disabled#disabled"}
 		,{"id":2022021801,"name":"News Feed: Keep your Page up to date","selector":".taijpn5t .ad2k81qe:not(.l6v480f0):not(.lzcic4wl) a[href*='/latest/'][href*=composer] .c1et5uql.bwm1u5wc","parent":".ad2k81qe.f9o22wc5 > div"}
 		,{"id":2022022501,"name":"News Feed: Facebook ad discount","selector":".taijpn5t .ad2k81qe:not(.l6v480f0):not(.lzcic4wl) a[href*='/ad_center/'][href*=coupon]","parent":".ad2k81qe.f9o22wc5 > div"}


### PR DESCRIPTION
The pivot points I was using were two width-sensitive hiders, which
their latest HTML I'm getting no longer uses.  In fact, something I've
never seen before in New Layout, one of the classname gibberishes they
were using has actually been deleted from their CSS definitions.

I'm updating all 6 that were using '.lntdvkbv,.bexiecsf', although I
only see two on my account ('About' and 'Recent Media'); and one which
wasn't, which I also do see.

As usual, the rest is all guesswork until users shout...

I'm also renaming them all from 'Group Right Col: whatever' to just
'Group: whatever', because in different layouts they appear either in
the right column or above the group's posts feed.

hideable.json: update and rename 2020121301 'Group: About'
hideable.json: update and rename 2020121303 'Group: Recent Media'
hideable.json: update and rename 2020121302 'Group: Popular Topics'
hideable.json: update and rename 2020121304 'Group: Events'
hideable.json: update and rename 2021060601 'Group: Recent Files'
hideable.json: update and rename 2021060602 'Group: Rooms'
hideable.json: update and rename 2022020701 'Group: Create subgroup'