### PR TITLE
2 new hideables, one pre-disabled until tooltips work

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -352,5 +352,7 @@
 		,{"id":2022022501,"name":"News Feed: Facebook ad discount","selector":".taijpn5t .ad2k81qe:not(.l6v480f0):not(.lzcic4wl) a[href*='/ad_center/'][href*=coupon]","parent":".ad2k81qe.f9o22wc5 > div"}
 		,{"id":2022031401,"name":"Business Page Inbox: Personalized Suggestions","selector":"[data-pagelet=BizWebInbox] .puibpoiz.hn745mhl.tcwtoxnz > .aa8h9o0m.duy2mlcu [role=button].iqnsra4u:not(.rbzcxh88)","parent":".hn745mhl"}
 		,{"id":2022040101,"name":"Left Rail: Professional Dashboard","selector":"[role=navigation].rek2kq2y a[href*=professional_dashboard]"}
+		,{"id":2022042201,"name":"Group: community fundraisers","selector":"[data-pagelet=GroupFeed] .ni8dbmo4 ~ .oygrvhab.ii04i59q .hnhda86s.b0tq1wua.oo9gr5id.hzawbc8m","parent":"[data-pagelet=GroupFeed] > *"}
+		,{"id":2022042202,"name":"Chat pop-unders (*ALL* CHAT POP-UNDERS, EVEN IF YOU MADE IT ON PURPOSE!) [DISABLED]","selector":"xxx [role=banner] ~ [data-visualcompletion] .aovydwv3 > .j83agx80.i09qtzwb > *","DOC":"initially disabled because this is too dangerous without working tooltips; enable after release of 29.0"},
 	]
 }


### PR DESCRIPTION
hideable.json: add 2022042201 'Group: community fundraisers'
hideable.json: add 2022042202 'Chat pop-unders (*ALL* CHAT POP-UNDERS, EVEN IF YOU MADE IT ON PURPOSE!) [DISABLED]'

Chat pop-unders is disabled because (from past experience) people turn
it on, then are completely flummoxed where their chat pop-unders went.
Enable it when 29.0 is shipping, with fully operational tooltips...
![hide-community-fundraisers](https://user-images.githubusercontent.com/3022180/164872604-adb25c2c-ea16-49c4-8284-c5cdda12a4d6.png)
![hide-chat-popunders](https://user-images.githubusercontent.com/3022180/164872611-e4454532-f1ce-401c-9ef3-f7aeb4ea30d7.png)
