### PR TITLE
top bar button hider fixes

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -220,7 +220,7 @@
 		,{"id":2020120703,"name":"Header: 'Home' button","selector":"[role=banner] [role=navigation] a.bp9cbjyn[href='/']"}
 		,{"id":2020120704,"name":"Header: 'Gaming' button","selector":"[role=banner] [role=navigation] a[href*='/gaming/']"}
 		,{"id":2020120705,"name":"Header: 'More (Bookmarks)' button","selector":"[role=banner] [role=navigation] a[href*='/bookmarks/']"}
-		,{"id":2020120706,"name":"Header: 'My profile' button","selector":"[role=banner] [role=navigation].rl25f0pe a[href*='/me/']","parent":"[role=banner] [role=navigation] > * > *"}
+		,{"id":2020120706,"name":"Header: 'Self' button","selector":"[role=banner] [role=navigation].rl25f0pe a[href*='/me/'] > div","parent":"[role=banner] [role=navigation] > * > *"}
 		,{"id":2020121301,"name":"Group: About","selector":".rek2kq2y.l9j0dhe7.aghb5jc5 .cwj9ozl2 .i1fnvgqd .o8rfisnq.cbu4d94t","parent":".j83agx80.l9j0dhe7.k4urcfbm"}
 		,{"id":2020121302,"name":"Group: Popular Topics","selector":".rek2kq2y.l9j0dhe7.aghb5jc5 a[href*='/groups/'][href*='/post_tags/'],.rek2kq2y.l9j0dhe7.aghb5jc5 a[href*='/hashtag/']","parent":".j83agx80.l9j0dhe7.k4urcfbm"}
 		,{"id":2020121303,"name":"Group: Recent Media","selector":".rek2kq2y.l9j0dhe7.aghb5jc5 .cwj9ozl2 .i1fnvgqd a[href*='/photo/'],.rek2kq2y.l9j0dhe7.aghb5jc5 .cwj9ozl2 .i1fnvgqd a[href*='/video/']","parent":".j83agx80.l9j0dhe7.k4urcfbm"}
@@ -280,7 +280,7 @@
 		,{"id":2021042901,"name":"Header: 'Notifications' menu","selector":"[role=banner] [role=navigation].rl25f0pe [href*='/notifications'],[role=banner] [role=navigation].rl25f0pe [aria-label*=Notifications]","parent":"[role=banner] [role=navigation] > * > *"}
 		,{"id":2021042902,"name":"Header: 'Create' menu","selector":"[role=banner] [role=navigation].rl25f0pe [aria-label*=Create]","parent":"[role=banner] [role=navigation] > * > *"}
 		,{"id":2021042903,"name":"Header: 'Messenger' menu","selector":"[role=banner] [role=navigation].rl25f0pe [aria-label*=Messenger]","parent":"[role=banner] [role=navigation] > * > *"}
-		,{"id":2021042904,"name":"Header: 'Account' button [DISABLED]","selector":"xxx [role=banner] [role=navigation].rl25f0pe [aria-label*=Account]","parent":"[role=banner] [role=navigation] > * > *"}
+		,{"id":2021042904,"name":"Header: 'Your profile' button [DISABLED]","selector":"xxx [role=banner] [role=navigation].rl25f0pe [aria-label*='Your profile']","parent":"[role=banner] [role=navigation] > * > *","DOC":"disabled as too dangerous to FB user interface"}
 		,{"id":2021042905,"name":"Header: 'Pages' button","selector":"[role=banner] [role=navigation] a[href*=your_pages]"}
 		,{"id":2021042906,"name":"Header: 'Menu' menu","selector":"[role=banner] [role=navigation].rl25f0pe [aria-label*=Menu]","parent":"[role=banner] [role=navigation] > * > *"}
 		,{"id":2021050101,"name":"Header: 'News' button","selector":"[role=banner] [role=navigation] a[href*='/news/']"}


### PR DESCRIPTION
hideable.json: rename 2021042904 to 'Your profile' due to FB change
hideable.json: fix 2021042904 'Your profile' due to FB tooltip change
hideable.json: thus rename 2020120706 to 'Self'
hideable.json: fix 2020120706 'Self button', broken by hide.js ce2915e5

Reminder to myself: I occasionally retry to hide the top-bar buttons
with space removal (rather than just hiding their icons).  This doesn't
work because:

- on the right side (My profile, Menu, Create, Messenger, Notifications,
  Account) -- the buttons themselves are at the top of their respective
  HTML structures; hiding the parent hides all buttons at once

- on the left side ('f', Search, Home, Watch, Marketplace, Groups, News,
  Gaming, Friends, Pages, Events, Bookmarks) -- it is possible to hide
  the buttons and *part* of their space.  Each hidden button shuffles
  the rest over to the left, but not as much as it looks like it should

So although some 'improvement' could be made, it would be inconsistent
and even harder to explain than the current 'the button is gone but its
space is still held' behavior, I should stop trying to 'solve' this...