### PR TITLE
filters.json: fix bonehead error in 2021082601 'Suggested'

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -91,7 +91,7 @@
 		"description": "Hide 'Sponsored' posts from the News Feed"
 	}, {
 		"id": 2021082601,
-		"match": "ALL",
+		"match": "ANY",
 		"rules": [{
 			"target": "any",
 			"operator": "startswith",


### PR DESCRIPTION
Forgot to edit 'ALL' to 'ANY', so it insisted on *both* one of the
existing clauses *and* 'Reels'; which presumably = no posts ever...