### PR TITLE
tweaks.json: update 3 'Notification Bubble' for new FB gibberselectors

### DIFF
--- a/tweaks.json
+++ b/tweaks.json
@@ -10,7 +10,7 @@
 			"id" : 3,
 			"title" : "Hide Notification Bubble",
 			"description" : "When a new notification is added, it is displayed in the lower left corner. Enable this tweak to hide it.",
-			"css": "ul[data-gt*=\"\\\"ref\\\":\\\"beeper\\\"\"], ul.poy2od1o.p7hjln8o > li.pmk7jnqg.pedkr2u6.ilcmz9jb.j9ispegn > :not(.cwj9ozl2), .poy2od1o ul.p7hjln8o > li.pmk7jnqg.pedkr2u6.ilcmz9jb.j9ispegn > :not(.cwj9ozl2), .poy2od1o.kavbgo14[class*='-mode'] li > :not([class*='-mode']), .poy2od1o[class*='-mode'] > ul.p7hjln8o li.pedkr2u6.ilcmz9jb > :not([class*='-mode']) { display:none !important; } ul.poy2od1o.p7hjln8o > li, .poy2od1o ul.p7hjln8o > li { transition-property: none !important; }"
+			"css": "ul.poy2od1o.p7hjln8o > li.pmk7jnqg.pedkr2u6.ilcmz9jb.j9ispegn > :not(.cwj9ozl2), .poy2od1o ul.p7hjln8o > li.pmk7jnqg.pedkr2u6.ilcmz9jb.j9ispegn > :not(.cwj9ozl2), .poy2od1o.kavbgo14[class*='-mode'] li > :not([class*='-mode']), .poy2od1o[class*='-mode'] > ul.p7hjln8o li.pedkr2u6.ilcmz9jb > :not([class*='-mode']), .khm9p5p9[class*='-mode'] ul.s5oniofx li.cdum9rwi.rgt4ek0a > :not(.k0kqjr44):not([class*='-mode']) { display:none !important; } ul.poy2od1o.p7hjln8o > li, .poy2od1o ul.p7hjln8o > li, .khm9p5p9 ul.s5oniofx li { transition-property: none !important; }"
 		}, {
 			"id" : 5,
 			"title" : "Force Chat Popup To Default Colors",


### PR DESCRIPTION
Beginning of a flood.  They've completely replaced their previous suite of gibberish selectors with new ones; which appear, again, to be consistent across all users.  If they replace them every 2-3 years like this I guess it will be sort of tolerable.

Updates needed in other tweaks; hideables; a few filters; and quite a few places in SFx code itself.

wheeee.