### PR TITLE
update socialfixerdata for 2022 gibberish classes

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -57,7 +57,8 @@
 			"operator": "contains_selector",
 			"condition": {
 				"text": "[role=button],[role=link],._5pcp,._5pcq:has-visible-text(^(Chartered$|Спонз|Спонс|Được|Gespons|Hirdetés|Patrocin|Реклам|Publicid|Spons|Sponz|Χορηγ|広告|贊助|赞助|ממומ))"
-			}
+			},
+			"DOC": "Relies on 'x,y:has-visible-text(z)' improperly applying to both x & y"
 		}, {
 			"target": "any",
 			"operator": "contains_selector",
@@ -74,7 +75,7 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "a[aria-label][href*='/ads'][href*='/about'],a.b1v8xokw[href*='/ads'][href*='/about'],a.m9osqain[href*='/ads'][href*='/about'],._5pbw a[href^='/a'][href*='/ads'][href*='/about'],._5pbw~a[href^='/a'][href*='/ads'][href*='/about'],._5pbw~* a[href^='/a'][href*='/ads'][href*='/about']"
+				"text": "a[aria-label][href*='/ads'][href*='/about'],a.b1v8xokw[href*='/ads'][href*='/about'],a.m9osqain[href*='/ads'][href*='/about'],a.tes86rjd[href*='/ads'][href*='/about'],a.rtxb060y[href*='/ads'][href*='/about']"
 			}
 		}],
 		"actions": [{
@@ -88,7 +89,7 @@
 		"configurable_actions": true,
 		"title": "Hide Sponsored Posts",
 		"stop_on_match": true,
-		"description": "Hide 'Sponsored' posts from the News Feed"
+		"description": "Hide 'Sponsored' posts from the News Feed.  Updated 2022-08-23, supports 2020 & 2022 layouts."
 	}, {
 		"id": 2021082601,
 		"match": "ANY",
@@ -103,15 +104,15 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": ".tkr6xdv7 .bnpdmtie .oo9gr5id.lrazzd5p.c1et5uql:contains((.+))"
+				"text": ".tkr6xdv7 .bnpdmtie .oo9gr5id.lrazzd5p.c1et5uql,.b0ur3jhr .s4swhuz0 .pbevjfx6.innypi6y.gh25dzvf:contains((.+))"
 			},
-			"DOC": "This is targeted at the 'Reels' fakeposts; it uses a particularly weak selector, hopefully will not have false matches"
+			"DOC": "This is targeted at the 'Reels' fakeposts; it uses a particularly weak selector, hopefully will not have false matches.  Relies on 'x,y:contains(z)' improperly applying to both x & y"
 		},
 		{
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "[sfx_post] .qan41l3s a.k4urcfbm.qensuy8j[href*='/reel/'],a.ns4ygwem[href*='/reel/']"
+				"text": "[sfx_post] .qan41l3s a.k4urcfbm.qensuy8j[href*='/reel/'],a.ns4ygwem[href*='/reel/'],[sfx_post] .o565dech a.mfclru0v.tghlliq5[href*='/reel/'],a.r5a47i9s[href*='/reel/']"
 			},
 			"DOC": "Different sorts of 'Reels' fakeposts"
 		},
@@ -119,9 +120,9 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": ".hybvsw6c.nwvqtn77 .tkr6xdv7 h3.lzcic4wl .b0tq1wua.lrazzd5p.m9osqain:contains((.+))"
+				"text": ".hybvsw6c.nwvqtn77 .tkr6xdv7 h3.lzcic4wl .b0tq1wua.lrazzd5p.m9osqain,.oab4agdp.a96hb305 .b0ur3jhr h3.icdlwmnq .ocv3nf92.innypi6y.rtxb060y:contains((.+))"
 			},
-			"DOC": "This is targeted at the 'People You May Know' fakeposts"
+			"DOC": "This is targeted at the 'People You May Know' fakeposts.  Relies on 'x,y:contains(z)' improperly applying to both x & y"
 		}],
 		"actions": [{
 			"action": "hide",
@@ -134,7 +135,7 @@
 		"configurable_actions": true,
 		"title": "Hide Suggested Posts",
 		"stop_on_match": true,
-		"description": "Hide various sorts of 'Suggested' posts in News & Groups Feeds (NOTE: English-language FB only)"
+		"description": "Hide various sorts of 'Suggested' posts in News & Groups Feeds (NOTE: English-language FB only).  Updated 2022-08-23, supports 2020 & 2022 layouts."
 	}, {
 		"id": 5,
 		"match": "ALL",
@@ -240,14 +241,15 @@
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": "a[ajaxify^='/friends/pymk'] [data-pymk-id],a[aria-label][href*='/friends'] .lrazzd5p.q66pz984"
+				"text": "a[ajaxify^='/friends/pymk'] [data-pymk-id],a[aria-label][href*='/friends'] .lrazzd5p.q66pz984,a[aria-label][href*='/friends'] .innypi6y.d1w2l3lo"
 			}
 		}, {
 			"target": "any",
 			"operator": "contains_selector",
 			"condition": {
-				"text": ".lrazzd5p.m9osqain:contains(^People [Yy]ou [Mm]ay [Kk]now$)"
-			}
+				"text": ".lrazzd5p.m9osqain,.innypi6y.rtxb060y:contains(^People [Yy]ou [Mm]ay [Kk]now$)"
+			},
+			"DOC": "Relies on 'x,y:contains(z)' improperly applying to both x & y"
 		}],
 		"actions": [{
 			"action": "hide",
@@ -255,7 +257,7 @@
 		}],
 		"configurable_actions": true,
 		"title": "Hide 'People You May Know'",
-		"description": "Filter the 'People You May Know' story that appears in the News Feed occasionally."
+		"description": "Filter the 'People You May Know' story that appears in the News Feed occasionally.  Updated 2022-08-23, supports 2020 & 2022 layouts."
 	}, {
 		"id": 11,
 		"match": "ALL",

--- a/hideable.json
+++ b/hideable.json
@@ -367,5 +367,73 @@
 		,{"id":2022060402,"name":"Post: Sticker Suggestions","selector":"[sfx_post] .ho8ehabp .i1fnvgqd .jifvfom9 div[role=button].qensuy8j.l9j0dhe7 img.pmk7jnqg+.b5wmifdl","parent":".ho8ehabp > *"}
 		,{"id":2022072801,"name":"Post: Emoji Suggestions","selector":"[sfx_post] .ho8ehabp .i1fnvgqd .jifvfom9 div[role=button].qensuy8j.l9j0dhe7 img[src*=emoji]","parent":".ho8ehabp > *"}
 		,{"id":2022081001,"name":"Profile: People You May Know","selector":"a[aria-hidden][href*='friends/suggestions'].kr520xx4.n7fi1qx3.pmk7jnqg","parent":"div.d2edcug0.cbu4d94t > div.d2edcug0.rq0escxv"}
+		,{"id":2022082301,"name":"Chat pop-unders (*ALL* CHAT POP-UNDERS, EVEN IF YOU MADE IT ON PURPOSE!) [DISABLED] (2022)","selector":"xxx [role=banner] ~ [data-visualcompletion] .gldv74r8 > .alzwoclg.z6erz7xo > *","DOC":"initially disabled because this is too dangerous without working tooltips; enable after release of 29.0"}
+		,{"id":2022082302,"name":"Friends page: People You May Know (2022)","selector":"html[sfx_url='/friends'] .jl2a5g8c.o9w3sbdw > .cqf1kptm[role=navigation]"}
+		,{"id":2022082303,"name":"Give Award (Post Comment) (2022)","selector":"[role=article] li span[aria-hidden=true] ~ .o9w3sbdw","parent":"li"}
+		,{"id":2022082304,"name":"Global Panel: Groups (2022)","selector":".khm9p5p9.arhryugz .pytsy3co > .pytsy3co .tghlliq5:not(.kjdc1dyq)[role=button] > .odagglqh","parent":".cqf1kptm"}
+		,{"id":2022082305,"name":"Global Panel: Home (Facebook) (2022)","selector":".khm9p5p9.arhryugz a[href='https://www.facebook.com']","parent":".cqf1kptm"}
+		,{"id":2022082306,"name":"Global Panel: List of groups (2022)","selector":".khm9p5p9.arhryugz .pytsy3co > .pytsy3co div.cqf1kptm ~ div > .cqf1kptm","parent":"div ~ div"}
+		,{"id":2022082307,"name":"Global Panel: Menu (2022)","selector":".khm9p5p9.arhryugz .pytsy3co > .pytsy3co .tghlliq5.kjdc1dyq[role=button] > .odagglqh","parent":".cqf1kptm"}
+		,{"id":2022082308,"name":"Global Panel: Messenger (2022)","selector":".khm9p5p9.arhryugz span .bdao358l span .tghlliq5[role=button] > .odagglqh","parent":".cqf1kptm > *"}
+		,{"id":2022082309,"name":"Global Panel: Notifications (2022)","selector":".khm9p5p9.arhryugz a[href*='/notifications']","parent":".cqf1kptm > *"}
+		,{"id":2022082310,"name":"Global Panel: Search Facebook (2022)","selector":".khm9p5p9.arhryugz .alzwoclg ~ .alzwoclg > span.rfyhaz4c .tghlliq5[role=button] > .odagglqh","parent":".cqf1kptm > *"}
+		,{"id":2022082311,"name":"Global Panel: Watch (2022)","selector":".khm9p5p9.arhryugz a[href*='/watch']","parent":".cqf1kptm > *"}
+		,{"id":2022082312,"name":"Global Panel: Your Profile (2022)","selector":".khm9p5p9.arhryugz .i8zpp7h3 > svg.i8zpp7h3[role=img]","parent":".cqf1kptm"}
+		,{"id":2022082313,"name":"Group: About (2022)","selector":".sl4bvocy.om3e55n1.s9djjbeh .k0kqjr44 .sl27f92c .gb2oqlaf.cqf1kptm","parent":".alzwoclg.om3e55n1.mfclru0v"}
+		,{"id":2022082314,"name":"Group Admin: 'Admin Assist' advertisement (2022)","selector":"[role=main] .gvxzyvdx .rj2hsocd a[href*='/admin_assistant']","parent":".rj2hsocd"}
+		,{"id":2022082315,"name":"Group Admin: Pending Posts bulk approve / decline (2022)","selector":"html[sfx_url*='/pending_posts'] [role=main] .thmcm15y.gvxzyvdx .g4tp4svg.km253p1d .oab4agdp > .bdao358l:nth-of-type(3) > div","parent":".oab4agdp > .bdao358l"}
+		,{"id":2022082316,"name":"Group Admin: 'Pending Posts' header (2022)","selector":"html[sfx_url*='/pending_posts'] [role=main] .thmcm15y.gvxzyvdx .g4tp4svg.km253p1d .oab4agdp > .bdao358l:nth-of-type(1) > div","parent":".oab4agdp > .bdao358l"}
+		,{"id":2022082317,"name":"Group Admin: Pending Posts search-by-name box (2022)","selector":"html[sfx_url*='/pending_posts'] [role=main] .thmcm15y.gvxzyvdx .g4tp4svg.km253p1d .oab4agdp > .bdao358l:nth-of-type(2) > div","parent":".oab4agdp > .bdao358l"}
+		,{"id":2022082318,"name":"Group: community fundraisers (2022)","selector":"[data-pagelet=GroupFeed] .lq84ybu9 ~ .kjdc1dyq.n3t5jt4f .o48pnaf2.ocv3nf92.pbevjfx6.ztn2w49p","parent":"[data-pagelet=GroupFeed] > *"}
+		,{"id":2022082319,"name":"Group: Create subgroup (2022)","selector":".sl4bvocy.om3e55n1.s9djjbeh .kjdc1dyq.n3t5jt4f ~ div .o9w3sbdw.sl27f92c.sr926ui1","parent":".alzwoclg.om3e55n1.mfclru0v"}
+		,{"id":2022082320,"name":"Group: Events (2022)","selector":".sl4bvocy.om3e55n1.s9djjbeh a[href*='/events/']","parent":".alzwoclg.om3e55n1.mfclru0v"}
+		,{"id":2022082321,"name":"Group Feed: See the latest coronavirus info (2022)","selector":"[data-pagelet=GroupFeed] .sl27f92c [href*=coronavirus_info]","parent":"[data-pagelet] > *"}
+		,{"id":2022082322,"name":"Group: Popular Topics (2022)","selector":".sl4bvocy.om3e55n1.s9djjbeh a[href*='/groups/'][href*='/post_tags/'],.sl4bvocy.om3e55n1.s9djjbeh a[href*='/hashtag/']","parent":".alzwoclg.om3e55n1.mfclru0v"}
+		,{"id":2022082323,"name":"Group: Recent Files (2022)","selector":".sl4bvocy.om3e55n1.s9djjbeh a[href*='/files/']","parent":".alzwoclg.om3e55n1.mfclru0v"}
+		,{"id":2022082324,"name":"Group: Recent Media (2022)","selector":".sl4bvocy.om3e55n1.s9djjbeh .k0kqjr44 .sl27f92c a[href*='/photo/'],.sl4bvocy.om3e55n1.s9djjbeh .k0kqjr44 .sl27f92c a[href*='/video/']","parent":".alzwoclg.om3e55n1.mfclru0v"}
+		,{"id":2022082325,"name":"Group: Rooms (2022)","selector":".sl4bvocy.om3e55n1.s9djjbeh .i85zmo3j.jcxyg2ei.cqf1kptm .hsphh064.rtxb060y","parent":".alzwoclg.om3e55n1.mfclru0v"}
+		,{"id":2022082326,"name":"Groups Feed Right Col: ad to join groups (2022)","selector":".s9djjbeh.sl4bvocy.i15ihif8 [href*='groups/discover/']","parent":".km253p1d > *"}
+		,{"id":2022082327,"name":"Groups Feed Right Col: Popular Now (2022)","selector":".s9djjbeh.sl4bvocy.i15ihif8 [href*='/topic/']","parent":".km253p1d > *"}
+		,{"id":2022082328,"name":"New chat message (2022)","selector":".khm9p5p9.z6erz7xo.on4d8346 .s8sjc6am ul.cqf1kptm ~ .axrg9lpx"}
+		,{"id":2022082329,"name":"News Feed: Add a WhatsApp Button (2022)","selector":".jcxyg2ei > .gvxzyvdx > .pry8b2m5:not(.aiyajaxl):not(.icdlwmnq) a[href*='/settings/whatsapp']","parent":".pry8b2m5 > *"}
+		,{"id":2022082330,"name":"News Feed: Create Story (2022)","selector":"[href*='stories/create'].o9w3sbdw","parent":"[data-pagelet]"}
+		,{"id":2022082331,"name":"News Feed: Facebook ad discount (2022)","selector":".jcxyg2ei .pry8b2m5:not(.aiyajaxl):not(.icdlwmnq) a[href*='/ad_center/'][href*=coupon]","parent":".pry8b2m5 > *"}
+		,{"id":2022082332,"name":"News Feed: Finish Donation (2022)","selector":".jcxyg2ei .pry8b2m5:not(.aiyajaxl):not(.icdlwmnq) a[href*=donation_reminder]","parent":".pry8b2m5 > *"}
+		,{"id":2022082333,"name":"News Feed: Home-Favorites-Recent bar (2022)","selector":"[role=main] > .jez8cy9q.cqf1kptm > .km253p1d.sl4bvocy > *"}
+		,{"id":2022082334,"name":"News Feed: Keep your Page up to date (2022)","selector":".jcxyg2ei .pry8b2m5:not(.aiyajaxl):not(.icdlwmnq) a[href*='/latest/'][href*=composer] .qtx5e3l4","parent":".pry8b2m5 > *"}
+		,{"id":2022082335,"name":"News Feed: Remember Password prompt (2022)","selector":".jcxyg2ei .pry8b2m5:not(.aiyajaxl):not(.icdlwmnq) img[src*=switch]","parent":".pry8b2m5 > *"}
+		,{"id":2022082336,"name":"News Feed: Rooms (2022)","selector":".oab4agdp > [role=tablist] ~ * [role=region] .lpbw5u4u [aria-label].tghlliq5","parent":"[role=tablist] ~ * > *"}
+		,{"id":2022082337,"name":"News Feed: Reels (2022)","selector":".oab4agdp > [role=tablist] ~ * [role=region] .lpbw5u4u a[href*='/reel/']","parent":"[role=tablist] ~ * > *"}
+		,{"id":2022082338,"name":"News Feed: Stories-Reels-Rooms header (2022)","selector":".oab4agdp > [role=tablist]"}
+		,{"id":2022082339,"name":"News Feed: Take A Survey prompt (2022)","selector":".jcxyg2ei .pry8b2m5:not(.aiyajaxl):not(.icdlwmnq) a[href*='/survey/'] ~ * a .lx3q5kuj","parent":".pry8b2m5 > *"}
+		,{"id":2022082340,"name":"Post: Ask Your Community for Support (2022)","selector":"[role=article] .ehmybnwb.om3e55n1 [href*='/fundraiser/with_presence/create_dialog']","parent":".ehmybnwb.om3e55n1"}
+		,{"id":2022082341,"name":"Post: Climate Science (2022)","selector":"[role=article] .oab4agdp a[href*=climatescience]","parent":".g4qalytl"}
+		,{"id":2022082342,"name":"Post Comment: Awards Given (2022)","selector":"[role=article] [role=article] .bq6c9xl4 .jjot6st7.mivixfar.sj8xpbrj","parent":"[role=button]"}
+		,{"id":2022082343,"name":"Post: Comment Suggestions (2022)","selector":"[sfx_post] .kgxy6ixo .sl27f92c .t5n4vrf6 div[role=button].tghlliq5.om3e55n1 .qxuwncqo+.jkp44r48","parent":".kgxy6ixo > *"}
+		,{"id":2022082344,"name":"Post: Covid Info (2022)","selector":"[role=article] .oab4agdp a[href*=coronavirus]","parent":".g4qalytl"}
+		,{"id":2022082345,"name":"Post: Create subgroup (2022)","selector":"[role=article] .alzwoclg.i85zmo3j.sl27f92c.mfycix9x a[href*=subfeed_recommendation]","parent":".alzwoclg.i85zmo3j.sl27f92c.mfycix9x"}
+		,{"id":2022082346,"name":"Post: Emoji Suggestions (2022)","selector":"[sfx_post] .kgxy6ixo .sl27f92c .t5n4vrf6 div[role=button].tghlliq5.om3e55n1 img[src*=emoji]","parent":".kgxy6ixo > *"}
+		,{"id":2022082347,"name":"Post: FB pay-for-exposure ad (2022)","selector":"[role=article] .ehmybnwb.om3e55n1 [href*='/community_help/?page_source=gather_upsell']","parent":".ehmybnwb.om3e55n1"}
+		,{"id":2022082348,"name":"Post: Find volunteers (2022)","selector":"[role=article] .ehmybnwb.om3e55n1 .sr926ui1 .nu7423ey[aria-label='Find volunteers']","parent":".ehmybnwb.om3e55n1"}
+		,{"id":2022082349,"name":"Post: Let more people see (2022)","selector":"[role=article] .g4qalytl.ehmybnwb.om3e55n1 [aria-label*='Let more people see']","parent":".g4qalytl.ehmybnwb.om3e55n1"}
+		,{"id":2022082350,"name":"Post: Recommend a thing (2022)","selector":"[role=article] [role=article] .gh25dzvf [role=link].t45fpzwc > .mfycix9x","parent":".gh25dzvf"}
+		,{"id":2022082351,"name":"Post: see groups like ... (2022)","selector":"[role=article] .mfycix9x.i85zmo3j a[href*='/discover/'][href*=group_trend]","parent":".mfycix9x.i85zmo3j"}
+		,{"id":2022082352,"name":"Post: Sticker Suggestions (2022)","selector":"[sfx_post] .kgxy6ixo .sl27f92c .t5n4vrf6 div[role=button].tghlliq5.om3e55n1 img.s8sjc6am+.jkp44r48","parent":".kgxy6ixo > *"}
+		,{"id":2022082353,"name":"Post: Subscribe Now (2022)","selector":"[role=article] a[aria-label][href*='/support'][href*=entrypoint]","parent":"a[aria-label].fxk3tzhb"}
+		,{"id":2022082354,"name":"Profile: Add to Story (2022)","selector":"[href*='stories/create']","parent":"[data-pagelet] .i15ihif8 > .mfclru0v"}
+		,{"id":2022082355,"name":"Profile: People You May Know (2022)","selector":"a[aria-hidden][href*='friends/suggestions'].ekq1a7f9.on4d8346.s8sjc6am","parent":"div.gvxzyvdx.cqf1kptm > div.gvxzyvdx.bdao358l"}
+		,{"id":2022082356,"name":"Right Rail: Birthdays (2022)","selector":".red7f7t1.sr926ui1 [role=complementary] .h67akvdo > .cgu29s5g > div [href*='/events/birthdays']","parent":"[role=complementary] .h67akvdo > .cgu29s5g > div > * > *"}
+		,{"id":2022082357,"name":"Right Rail (entire block) (2022)","selector":"[role=complementary] :not(.oab4agdp) > .h67akvdo > .cgu29s5g > div"}
+		,{"id":2022082358,"name":"Right Rail: Friend Requests (entire block) (2022)","selector":".red7f7t1.sr926ui1 [role=complementary] .h67akvdo > .cgu29s5g > div [href*='/friends/'][href*=profile_id]","parent":"[role=complementary] .h67akvdo > .cgu29s5g > div > * > *"}
+		,{"id":2022082359,"name":"Right Rail: Friend Requests (list) (2022)","selector":".red7f7t1.sr926ui1 [role=complementary] .h67akvdo > .cgu29s5g > div [href*='/friends/'][href*=profile_id]"}
+		,{"id":2022082360,"name":"Right Rail: Group conversations (2022)","selector":".red7f7t1.sr926ui1 [role=complementary] .h67akvdo > .cgu29s5g > div > [data-visualcompletion] + [data-visualcompletion]"}
+		,{"id":2022082361,"name":"Right Rail: Live Video (2022)","selector":".red7f7t1.sr926ui1 [role=complementary] .h67akvdo > .cgu29s5g > div [href*='/watch/live']","parent":"[role=complementary] .h67akvdo > .cgu29s5g > div > * > *"}
+		,{"id":2022082362,"name":"Right Rail: Play Games (2022)","selector":".red7f7t1.sr926ui1 [role=complementary] .h67akvdo > .cgu29s5g > div a[href*='/gam'][href*=rhc_discovery]","parent":"[role=complementary] .h67akvdo > .cgu29s5g > div > * > *"}
+		,{"id":2022082363,"name":"Right Rail: Recently Saved (2022)","selector":".red7f7t1.sr926ui1 [role=complementary] .h67akvdo > .cgu29s5g > div a[href*='/saved']","parent":"[role=complementary] .h67akvdo > .cgu29s5g > div > * > *"}
+		,{"id":2022082364,"name":"Right Rail: See All Contacts (2022)","selector":".red7f7t1.sr926ui1 [role=complementary] .h67akvdo > .cgu29s5g > div .gt60zsk1 > [role=button].jcxyg2ei.nu7423ey.fxk3tzhb"}
+		,{"id":2022082365,"name":"Right Rail: Sponsored (2022)","selector":".red7f7t1.sr926ui1 [role=complementary] .h67akvdo > .cgu29s5g > div .cqf1kptm .b6ax4al1>.kzwutkk6","parent":"[role=complementary] .h67akvdo > .cgu29s5g > div > * > *"}
+		,{"id":2022082366,"name":"Right Rail: Suggested Groups (2022)","selector":".red7f7t1.sr926ui1 [role=complementary] .h67akvdo > .cgu29s5g > div a[href$='/groups/']","parent":"[role=complementary] .h67akvdo > .cgu29s5g > div > * > *"}
+		,{"id":2022082367,"name":"Right Rail: Watch (2022)","selector":".red7f7t1.sr926ui1 [role=complementary] .h67akvdo > .cgu29s5g > div a[href*='/watch']","parent":"[role=complementary] .h67akvdo > .cgu29s5g > div > * > *"}
+		,{"id":2022082368,"name":"Right Rail: Your Pages (2022)","selector":".red7f7t1.sr926ui1 [role=complementary] .h67akvdo > .cgu29s5g > div a[href*='ad_center/create'][href*=rhc_page]","parent":"[role=complementary] .h67akvdo > .cgu29s5g > div > * > *"}
 	]
 }

--- a/tweaks.json
+++ b/tweaks.json
@@ -9,7 +9,7 @@
 		}, {
 			"id" : 3,
 			"title" : "Hide Notification Bubble",
-			"description" : "When a new notification is added, it is displayed in the lower left corner. Enable this tweak to hide it.",
+			"description" : "When a new notification is added, it is displayed in the lower left corner. Enable this tweak to hide it.  Updated 2022-08-20, supports 2020 & 2022 layouts.",
 			"css": "ul.poy2od1o.p7hjln8o > li.pmk7jnqg.pedkr2u6.ilcmz9jb.j9ispegn > :not(.cwj9ozl2), .poy2od1o ul.p7hjln8o > li.pmk7jnqg.pedkr2u6.ilcmz9jb.j9ispegn > :not(.cwj9ozl2), .poy2od1o.kavbgo14[class*='-mode'] li > :not([class*='-mode']), .poy2od1o[class*='-mode'] > ul.p7hjln8o li.pedkr2u6.ilcmz9jb > :not([class*='-mode']), .khm9p5p9[class*='-mode'] ul.s5oniofx li.cdum9rwi.rgt4ek0a > :not(.k0kqjr44):not([class*='-mode']) { display:none !important; } ul.poy2od1o.p7hjln8o > li, .poy2od1o ul.p7hjln8o > li, .khm9p5p9 ul.s5oniofx li { transition-property: none !important; }"
 		}, {
 			"id" : 5,
@@ -24,8 +24,8 @@
 		}, {
 			"id" : 2021093001,
 			"title": "Fix date-stamp blobs (v1.1a; NOT NEEDED IN SFx 28)",
-			"description": "This fix is no longer needed in Social Fixer 28.0 or newer.  You can disable it, test, then remove it if all goes well.  Please report in the Support Group (in wrench menu) if the date blobs come back.  Users of older SFx releases may still find this useful.",
-			"css": "/* Fix date-stamp blobs -- only for SFx older than 28.0 -- v1.1a 16Mar22\n\n   This actually works by fading out *all* hover blobs after\n   five seconds.  The blobs are still present but invisible. */\n\n[class*='-mode'] > .pmk7jnqg > [role=tooltip] { animation:sfx_nostamp 100000s !important; }\n@keyframes sfx_nostamp {\n  from { opacity:1; }\n  0.0050% { opacity:1; }\n  0.0055% { opacity:0; }\n  to { opacity:0; }\n}",
+			"description": "This fix is no longer needed in Social Fixer 28.0 or newer.  You can disable it, test, then remove it if all goes well.  Please report in the Support Group (in wrench menu) if the date blobs come back.  Users of older SFx releases may still find this useful.  Updated 2022-08-23, supports 2020 & 2022 layouts.",
+			"css": "/* Fix date-stamp blobs -- only for SFx older than 28.0 -- v1.1a 16Mar22\n\n   This actually works by fading out *all* hover blobs after\n   five seconds.  The blobs are still present but invisible. */\n\n[class*='-mode'] > .pmk7jnqg > [role=tooltip],[class*='-mode'] > .s8sjc6am > [role=tooltip] { animation:sfx_nostamp 100000s !important; }\n@keyframes sfx_nostamp {\n  from { opacity:1; }\n  0.0050% { opacity:1; }\n  0.0055% { opacity:0; }\n  to { opacity:0; }\n}",
 			"max_version": "27.99.99"
 		}, {
 			"id" : 2021100701,


### PR DESCRIPTION
This more or less brings everything up to date for the new set of classes.

All of the hiders, filters and tweaks have been kept backwards compatible with the 2020 classes, as I can't yet tell whether the rollout is universal or rolling.

I deleted some pre-2020 ('old layout') support.  The old layout ._abcd selectors **are** still used internally, in various ways, but I don't think any of the uses here are still relevant (for 2+ years).

Not everything has been tested, but a lot has, and the hit rate of the ones I was able to test (because FB sent me the relevant thing-to-hide-or-filter) was high enough to feel that all will work.  If not, it's mostly failure-by-omission: it won't filter the post, or won't hide the annoyance; there shouldn't be any whoops-hides-too-much.  I hope :)

Filters & tweaks will auto-update.

Hiders are new IDs, because combining multiple generations of hider in a single ID leads to problems.  So they won't auto-update, not even for people with the beta.  They'll have to go into Hide/Show and explicitly re-hide anything they want to hide.