### PR TITLE
support.html: add the software FAQ, differentiate from business FAQ

### DIFF
--- a/support.html
+++ b/support.html
@@ -15,7 +15,8 @@ When requesting support in any forum, it's always helpful to follow a few guidel
 <div>
 	<ol>
 		<li><a style="font-weight:bold;text-decoration:underline;color:#3B5998;" href="https://www.facebook.com/groups/SocialFixerUsersSupport/">Social Fixer User Support</a> : The Official support group on Facebook
-		<li><a style="font-weight:bold;text-decoration:underline;color:#3B5998;" href="http://SocialFixer.com/faq.html">FAQ</a>
+		<li><a style="font-weight:bold;text-decoration:underline;color:#3B5998;" href="http://tiny.cc/sfx-ug-faq">FAQ about software issues</a>
+		<li><a style="font-weight:bold;text-decoration:underline;color:#3B5998;" href="https://SocialFixer.com/faq.html">FAQ about business practices</a>
 		<li><a style="font-weight:bold;text-decoration:underline;color:#3B5998;" href="https://www.facebook.com/groups/SFxSnipDev/">SFx Snippet/Filter Development</a> : For community discussion of advanced CSS or Filters
 		<li><a style="font-weight:bold;text-decoration:underline;color:#3B5998;" href="https://www.facebook.com/groups/SFxOffTopic/">SFx Off-Topic</a> : An open forum of users, where any topic is welcome!
 	</ol>


### PR DESCRIPTION
Leaving this for a day or two for your review.  The FAQ previously pointed to is mostly about business positioning; I've added the UG FAQ which is mostly about software issues.  (Both are grossly out of date, in their own ways, but still apply to at least a moderate degree.)

I'm also pushing the change which makes all the in-software support buttons go to this page rather than the immediate redirect to the main group.  So that also remains up for your review, in the '2022b' branch waiting to be merged to main and shipped as a new beta.