### PR TITLE
Fix occasional lapse in 'Suggested' filter

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -93,6 +93,13 @@
 		"id": 2021082601,
 		"match": "ANY",
 		"rules": [{
+			"target": "action",
+			"operator": "startswith",
+			"condition": {
+				"text": ".{0,5}(?:Facebook ?){0,30}.{0,5}(Based on your recent|Because you may be interested in|Because you recently viewed|Because you viewed|Events you may like|From a group that|From a group with members who like|From a group you|Post from a public group|Suggested for you|Suggested pages|Suggested post|You recently viewed a similar group|More like|Suggested groups)"
+			}
+		},
+		{
 			"target": "any",
 			"operator": "startswith",
 			"condition": {


### PR DESCRIPTION
filters.json: 2021082601 'Suggested' check ${action} as well as ${all_content}

This is a workaround for occasionally blank ${all_content} (see SFx commit 540c80a).

Fix suggested by data from fb.com/963247941747750