### PR TITLE
filters.json: 11 'Friend Activity Stories' default to Hide post, not a tab

### DIFF
--- a/filters.json
+++ b/filters.json
@@ -300,8 +300,8 @@
 		}],
 		"actions": [{
 			"show_note": true,
-			"custom_note": "$1",
-			"action": "move-to-tab",
+			"custom_note": "Friend Activity: $1",
+			"action": "hide",
 			"tab": "Friend Activity"
 		}],
 		"configurable_actions": true,


### PR DESCRIPTION
Lots of users complain about  the Control Panel being activated by subscription filters.

This and the two 'create tab' filters ('Create Author Tabs', 'Create Game/App Tabs') are the only subscription filters which activate the CP.  The other two inherently require it for their functionality; this one is just an arbitrary choice, so I'm flipping the arbitrary choice.