### PR TITLE
hideable.json: add 2023071201 'Groups Feed: Chats you should join'

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -361,5 +361,6 @@
 		,{"id":2023013001,"name":"Left Rail 'animated': Watch","selector":".S2F_wid_100 [data-isanimatedlayout] a[href*='/watch/?']"}
 		,{"id":2023032401,"name":"Header: 'Feeds' button","selector":"[role=banner] [role=navigation] a[href*='filter=all']"}
 		,{"id":2023060399,"name":"Profile: Create with avatar","selector":"[aria-label][href*='set='] ~ div [aria-label*=avatar]"}
+		,{"id":2023071201,"name":"Groups Feed: Chats you should join","selector":"html[sfx_url*='/groups/'] [aria-label][role=grid] a[href*='/messages/'] .S2F_col_tx2","parent":".S2F_oscry_cont"}
 	]
 }


### PR DESCRIPTION
This was tricky because the blob-to-hide moves between top and right columns depending on zoom level.  This is not done with pure CSS; rather, FB rewrite *part* of the DOM on width changes.  I had to find a node which covered the entire blob but was not rewritten during a width change -- otherwise the blob would reappear on zoom in/out past the boundary size (but then disappear again on reload).

In the 2-column 'zoomed out' presentation, this also has the benefit of removing the space used, allowing the center column to expand.
![hide-chats-ysj](https://github.com/matt-kruse/socialfixerdata/assets/3022180/3178a21f-fa28-4fa0-9917-d28a2426dcfd)
