### PR TITLE
2 profile hiders: new PYMK + 'get Meta Verified'

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -176,5 +176,7 @@
                 ,{"id":2023092501,"name":"Media 1","selector":".S2F_padl_16 > .S2F_flex_wrap > .S2F_bb_dark:nth-of-type(1) > div:first-of-type"}
                 ,{"id":2023092502,"name":"Media 2","selector":".S2F_padl_16 > .S2F_flex_wrap > .S2F_bb_dark:nth-of-type(2) > div:first-of-type"}
                 ,{"id":2023092503,"name":"Media 3","selector":".S2F_padl_16 > .S2F_flex_wrap > .S2F_bb_dark:nth-of-type(3) > div:first-of-type"}
+                ,{"id":2023100301,"name":"Profile: People You May Know (2023)","selector":"h2 ~ span.S2F_col_acc a[href*='friends/suggestions'].S2F_font_600","parent":".S2F_disp_flex.S2F_wid_100"}
+                ,{"id":2023100501,"name":"Profile: get Meta Verified","selector":".S2F_mw_100 > a.S2F_disp_infl[href*='/meta_verified']","parent":".S2F_disp_flex.S2F_wid_100"}
 	]
 }


### PR DESCRIPTION
hideable.json: add 2023100301 'Profile: People You May Know (2023)'

per fb.com/1111120566960486 & conversation / field testing with user (testing still in progress, but it's gonna work and I'll add a screenshot then)

hideable.json: add 2023100501 'Profile: get Meta Verified'

per fb.com/1113301683409041, and then FB conveniently added it to my account...
![hide-verified-badge-ad](https://github.com/matt-kruse/socialfixerdata/assets/3022180/55779aa2-4fa4-4213-80a2-2641167538e0)