### PR TITLE
tweaks.json: fix 3 'Hide Notification Bubble'

### DIFF
--- a/tweaks.json
+++ b/tweaks.json
@@ -9,8 +9,8 @@
 		}, {
 			"id" : 3,
 			"title" : "Hide Notification Bubble",
-			"description" : "When a new notification is added, it is displayed in the lower left corner. Enable this tweak to hide it.  Updated 2022-08-20, supports 2020 & 2022 layouts.",
-			"css": "ul.poy2od1o.p7hjln8o > li.pmk7jnqg.pedkr2u6.ilcmz9jb.j9ispegn > :not(.cwj9ozl2),\n.poy2od1o ul.p7hjln8o > li.pmk7jnqg.pedkr2u6.ilcmz9jb.j9ispegn > :not(.cwj9ozl2),\n.poy2od1o.kavbgo14[class*='-mode'] li > :not([class*='-mode']),\n.poy2od1o[class*='-mode'] > ul.p7hjln8o li.pedkr2u6.ilcmz9jb > :not([class*='-mode']),\n.khm9p5p9[class*='-mode'] ul.s5oniofx li.cdum9rwi.rgt4ek0a > :not(.k0kqjr44):not([class*='-mode']),\n.xixxii4[class*='-mode'] ul.xe8uvvx li.x1hc1fzr.x7lz9yc > :not(.x1jx94hy):not([class*='-mode']),\n.S2F_pos_fix[class*='-mode'] ul.S2F_list_none li.S2F_opac_1.S2F_ttf_eei > :not(.S2F_bg_card):not([class*='-mode'])\n  { display:none !important; }\nul.poy2od1o.p7hjln8o > li,\n.poy2od1o ul.p7hjln8o > li,\n.khm9p5p9 ul.s5oniofx li,\n.xixxii4 ul.xe8uvvx li,\n.S2F_pos_fix ul.S2F_list_none li\n  { transition-property: none !important; }"
+			"description" : "When a new notification is added, it is displayed in the lower left corner. Enable this tweak to hide it.  Updated 2025-08-16, supports 2024-2025 layouts.",
+			"css": ".xixxii4[class*='-mode'] ul.xe8uvvx li.x1hc1fzr.x7lz9yc > :not(.x1jx94hy):not([class*='-mode']),\n.xixxii4[class*='-mode'] ul.x3ct3a4 li.x1hc1fzr.x7lz9yc > :not(.x1jx94hy):not([class*='-mode']),\n.S2F_pos_fix[class*='-mode'] ul.x3ct3a4 li.S2F_opac_1.S2F_ttf_eei > :not(.S2F_bg_card):not([class*='-mode']),\n.S2F_pos_fix[class*='-mode'] ul.S2F_list_none li.S2F_opac_1.S2F_ttf_eei > :not(.S2F_bg_card):not([class*='-mode'])\n  { display:none !important; }\n.xixxii4 ul.xe8uvvx li,\n.xixxii4 ul.x3ct3a4 li,\n.S2F_pos_fix ul.x3ct3a4 li\n.S2F_pos_fix ul.S2F_list_none li\n  { transition-property: none !important; }"
 		}, {
 			"id" : 5,
 			"title" : "Force Chat Popup To Default Colors",


### PR DESCRIPTION
They replaced .xe8uvvx { list-style: none; } with .x3ct3a4 { list-style-type: none; }

-- so, support both of those (the latter without gib support, until some maybe-future release of SFx).

Also clearing away ancient 2020 & 2022 decoded gib support.