### PR TITLE
more left-rail hider details

### DIFF
--- a/hideable.json
+++ b/hideable.json
@@ -22,7 +22,7 @@
 		,{"id":2020082305,"name":"Header: 'Marketplace' button","selector":"[role=banner] [role=navigation] a[href*='/marketplace']"}
 		,{"id":2020082306,"name":"Header: 'Groups' button","selector":"[role=banner] [role=navigation] a[href*='/groups']"}
 		,{"id":2020082502,"name":"Post: View Insights","selector":"div+div+div[data-visualcompletion] > a[href*='/post_insights/']"}
-		,{"id":2020082901,"name":"Left Rail (entire block -- TO HIDE SINGLE ITEMS, SCROLL PAST 2 POSTS)","selector":"[role=banner] ~ * [role=navigation].S2F_top_hdrh"}
+		,{"id":2020082901,"name":"Left Rail (ENTIRE BLOCK, in Top Stories -- TO HIDE SINGLE ITEMS, SCROLL PAST 2 POSTS)","selector":"[role=banner] ~ * [role=navigation]:has(footer)"}
 		,{"id":2020091901,"name":"Post: Voting Information Center","selector":"[sfx_post] ._3x-2 ~ div a[href*='/votinginformationcenter/']"}
 		,{"id":2020120701,"name":"Header: 'f' button","selector":"[role=banner] > :first-child a[href='/']"}
 		,{"id":2020120702,"name":"Header: 'Search Facebook' box","selector":"[role=banner] input[type=search]","parent":"label"}
@@ -169,7 +169,7 @@
 		,{"id":2023060399,"name":"Profile: Create with avatar","selector":"[aria-label][href*='set='] ~ div [aria-label*=avatar]"}
 		,{"id":2023071201,"name":"Groups Feed: Chats you should join","selector":"html[sfx_url*='/groups/'] [aria-label][role=grid] a[href*='/messages/'] .S2F_col_tx2","parent":".S2F_oscry_cont"}
 		,{"id":2023081700,"name":"Left Rail: Meta Quest","selector":"[role=banner] ~ * [role=navigation] a[href*='meta.com'][href*=quest]"}
-		,{"id":2023081701,"name":"Left Rail: Feeds","selector":"[role=banner] ~ * [role=navigation] a[href*='filter=all']"}
+		,{"id":2023081701,"name":"[DISABLED] Left Rail: Feeds: All","selector":"xxx [role=banner] ~ * [role=navigation] a[href*='filter=all']","DOC":"Displays underneath 2026032407 -- cannot be accessed"}
 		,{"id":2023091300,"name":"NOT LOGGED IN: See more on Facebook (overlay)","selector":"form[action*=login] a[href*='/recover/initiate'].S2F_col_acc","parent":".S2F_zi_0 > .S2F_disp_flex"}
 		,{"id":2023091301,"name":"NOT LOGGED IN: Create Account (form)","selector":"a[href*='/login/?next=']","parent":".S2F_bg_surf.S2F_pos_fix > *"}
 		,{"id":2023091302,"name":"NOT LOGGED IN: Create Account (shelf)","selector":"a[href*='/login/?next=']","parent":".S2F_bg_surf.S2F_pos_fix"}
@@ -187,9 +187,10 @@
 		,{"id":2025110301,"name":"Header: 'Reels' button","selector":"[role=banner] [role=navigation] a[href*='/reel/']"}
 		,{"id":2026032401,"name":"News Feed: Remember Password prompt (2026)","selector":"[role=main] .S2F_fldr_row.S2F_just_cent > .S2F_mw_100 > .S2F_mb_0 img[src*=switch]","parent":".S2F_fldr_row.S2F_just_cent > .S2F_mw_100 > *"}
 		,{"id":2026032402,"name":"Profile: Share a thought","selector":".S2F_disp_flex.S2F_zi_1.S2F_pos_abs > [role=button].S2F_alini_stre.S2F_disp_infl > .S2F_pos_abs.S2F_zi_1 > * "}
-		,{"id":2026032403,"name":"[NOT RECOMMENDED!] Left Rail (entire block, in messages)","selector":"[role=banner] ~ * [role=navigation].S2F_flex_shr1"}
+		,{"id":2026032403,"name":"[NOT RECOMMENDED!] Left Rail (ENTIRE BLOCK, in Messages)","selector":"[role=banner] ~ * [role=navigation]:has([role=tablist])"}
 		,{"id":2026032404,"name":"Right Rail: Birthdays (2026)","selector":".S2F_fhd_wide.S2F_flwr_no [role=complementary] [href*='/events/birthdays']","parent":".S2F_pos_rel.xyen2ro"}
 		,{"id":2026032405,"name":"Right Rail: Sponsored (2026)","selector":".S2F_fhd_wide.S2F_flwr_no [role=complementary] a[aria-labelledby][attributionsrc][href*=utm_c]","parent":".S2F_pos_rel.xyen2ro"}
 		,{"id":2026032406,"name":"Post: Annoying AI Questions","selector":"[sfx_post] .S2F_zi_0 > .S2F_zi_1[aria-hidden] ~ .S2F_bxs_bbox i[role=img][aria-label]","parent":".S2F_mb_0 > .S2F_mb_0 > .S2F_mb_0 > .S2F_bxs_bbox"}
+		,{"id":2026032407,"name":"Left Rail (ENTIRE BLOCK, in Feeds)","selector":"[role=banner] ~ * [role=navigation]:has(a[href*='/?filter='])"}
 	]
 }


### PR DESCRIPTION
hideable.json: add 2026032407 'Left Rail (ENTIRE BLOCK, in Feeds)' (NOTE: title is invisibly off-screen; can't fix this with current SFx code)
hideable.json: fix 2020082901 'Left Rail (ENTIRE BLOCK, in Top Stories -- TO HIDE SINGLE ITEMS, SCROLL PAST 2 POSTS)' to be more specific
hideable.json: fix 2026032403 '[NOT RECOMMENDED!] Left Rail (entire block, in messages)' to be more specific
hideable.json: disable 2023081701 'Left Rail: Feeds: All', as it can no longer be accessed (2026032407 overlays it)